### PR TITLE
Fixes missing name in the Taxonomy options hook

### DIFF
--- a/includes/classes/BlockCatalogTaxonomy.php
+++ b/includes/classes/BlockCatalogTaxonomy.php
@@ -91,7 +91,7 @@ class BlockCatalogTaxonomy {
 		 * @param string $name Taxonomy name.
 		 * @return array The new taxonomy options
 		 */
-		$options = apply_filters( 'block_catalog_taxonomy_options', $options );
+		$options = apply_filters( 'block_catalog_taxonomy_options', $options, $this->get_name() );
 
 		return $options;
 	}


### PR DESCRIPTION
### Description of the Change

Fixes the missing taxonomy name in the `block_catalog_taxonomy_options` hook.

### How to test the Change

Use the `block_catalog_taxonomy_options` hook and override any of the default taxonomy options in the array.

### Changelog Entry

Fixed - Missing name in the `block_catalog_taxonomy_options` hook

### Credits

Props @claytoncollie 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
