### PR TITLE
Feature/add multisite support from cli

### DIFF
--- a/includes/classes/CatalogBuilder.php
+++ b/includes/classes/CatalogBuilder.php
@@ -165,22 +165,22 @@ class CatalogBuilder {
 		}
 
 		foreach ( $output['variations'] ?? [] as $variation ) {
-			$blockName = $variation['blockName'];
-			$terms     = $variation['terms'] ?? [];
+			$block_name = $variation['blockName'];
+			$terms      = $variation['terms'] ?? [];
 
-			if ( empty( $blockName ) || empty( $terms ) ) {
+			if ( empty( $block_name ) || empty( $terms ) ) {
 				continue;
 			}
 
 			foreach ( $terms as $label ) {
-				$slug = $blockName . '-' . $label;
+				$slug = $block_name . '-' . $label;
 
 				if ( ! term_exists( $slug, BLOCK_CATALOG_TAXONOMY ) ) {
 					$term_args = [
 						'slug' => $slug,
 					];
 
-					$parent_id = $this->get_variation_parent_term( $blockName );
+					$parent_id = $this->get_variation_parent_term( $block_name );
 
 					if ( ! empty( $parent_id ) ) {
 						$term_args['parent'] = $parent_id;

--- a/includes/classes/CatalogBuilder.php
+++ b/includes/classes/CatalogBuilder.php
@@ -253,11 +253,14 @@ class CatalogBuilder {
 			}
 
 			if ( ! empty( $block_terms['variations'] ) ) {
-				$variations[] = array_merge( $variations, [
-					'blockName' => $block['blockName'],
-					'block'     => $block,
-					'terms'     => $block_terms['variations'],
-				] );
+				$variations[] = array_merge(
+					$variations,
+					[
+						'blockName' => $block['blockName'],
+						'block'     => $block,
+						'terms'     => $block_terms['variations'],
+					]
+				);
 			}
 		}
 
@@ -316,7 +319,10 @@ class CatalogBuilder {
 	 */
 	public function block_to_terms( $block, $opts = [] ) {
 		if ( empty( $block ) || empty( $block['blockName'] ) ) {
-			return [ 'terms' => [], 'variations' => [] ];
+			return [
+				'terms'      => [],
+				'variations' => [],
+			];
 		}
 
 		$terms = [];

--- a/includes/classes/CatalogCommand.php
+++ b/includes/classes/CatalogCommand.php
@@ -46,12 +46,13 @@ class CatalogCommand extends \WP_CLI_Command {
 		\BlockCatalog\Utility\start_bulk_operation();
 
 		$dry_run = ! empty( $opts['dry-run'] );
+		$network = $this->get_network_option( $opts );
 
-		if ( ! is_multisite() ) {
+		if ( empty( $network ) ) {
 			$opts['show_dry_run_warning'] = true;
 			$this->index_site( $args, $opts );
 		} else {
-			$blog_ids                     = $this->get_network_option( $opts );
+			$blog_ids                     = $network;
 			$opts['show_dry_run_warning'] = false;
 
 			if ( $dry_run ) {

--- a/includes/classes/CatalogCommand.php
+++ b/includes/classes/CatalogCommand.php
@@ -51,7 +51,7 @@ class CatalogCommand extends \WP_CLI_Command {
 			$opts['show_dry_run_warning'] = true;
 			$this->index_site( $args, $opts );
 		} else {
-			$blog_ids = $this->get_network_option( $opts );
+			$blog_ids                     = $this->get_network_option( $opts );
 			$opts['show_dry_run_warning'] = false;
 
 			if ( $dry_run ) {
@@ -307,7 +307,7 @@ class CatalogCommand extends \WP_CLI_Command {
 
 		if ( is_string( $network ) && in_array( $network, $accepted, true ) ) {
 			$query_params[ $network ] = 1;
-		} elseif ( is_array( $network ) && ! empty( $network) && is_numeric( $network[0] ) ) {
+		} elseif ( is_array( $network ) && ! empty( $network ) && is_numeric( $network[0] ) ) {
 			// list of site ids
 			$query_params['site__in'] = $network;
 		} else {
@@ -454,16 +454,16 @@ class CatalogCommand extends \WP_CLI_Command {
 		$output = [];
 
 		foreach ( $result as $result_item ) {
-			$error = $result_item['error'] ?? false;
-			$blog_id = $result_item['blog_id'];
+			$error    = $result_item['error'] ?? false;
+			$blog_id  = $result_item['blog_id'];
 			$blog_url = $result_item['blog_url'];
 
 			if ( is_wp_error( $error ) ) {
 				$output[] = [
-					'blog_id'  => $blog_id,
-					'blog_url' => $blog_url,
-					'ID'       => 0,
-					'post_type' => '',
+					'blog_id'    => $blog_id,
+					'blog_url'   => $blog_url,
+					'ID'         => 0,
+					'post_type'  => '',
 					'post_title' => $error->get_error_message(),
 				];
 			} else {

--- a/includes/classes/CatalogCommand.php
+++ b/includes/classes/CatalogCommand.php
@@ -265,6 +265,10 @@ class CatalogCommand extends \WP_CLI_Command {
 			return '';
 		}
 
+		if ( ! is_plugin_active_for_network( BLOCK_CATALOG_PLUGIN_FILE ) ) {
+			\WP_CLI::error( __( 'The --network option can only be used when the Block Catalog plugin is network activated.', 'block-catalog' ) );
+		}
+
 		$network = \WP_CLI\Utils\get_flag_value( $opts, 'network', 'public' );
 
 		// assume networks with commas are ids

--- a/includes/classes/CatalogCommand.php
+++ b/includes/classes/CatalogCommand.php
@@ -403,6 +403,10 @@ class CatalogCommand extends \WP_CLI_Command {
 	 * @param array $opts Optional arguments.
 	 */
 	private function count_on_network( $sites = [], $args = [], $opts ) {
+		if ( ! empty( $opts['index'] ) ) {
+			$this->index( $args, $opts );
+		}
+
 		$finder = new PostFinder();
 
 		$result = $finder->count_on_network( $sites, $args, $opts );
@@ -420,6 +424,10 @@ class CatalogCommand extends \WP_CLI_Command {
 	 * @param array $opts Optional arguments.
 	 */
 	private function count_on_site( $args = [], $opts ) {
+		if ( ! empty( $opts['index'] ) ) {
+			$this->index( $args, $opts );
+		}
+
 		$finder = new PostFinder();
 		$result = $finder->count( $args, $opts );
 

--- a/includes/classes/CatalogCommand.php
+++ b/includes/classes/CatalogCommand.php
@@ -281,7 +281,7 @@ class CatalogCommand extends \WP_CLI_Command {
 	 * throws an error if not.
 	 *
 	 * @param array $opts Optional opts
-	 * @return void
+	 * @return bool
 	 */
 	private function check_network_option( $opts ) {
 		if ( ! is_multisite() && isset( $opts['network'] ) ) {
@@ -428,6 +428,7 @@ class CatalogCommand extends \WP_CLI_Command {
 		}
 
 		if ( ! empty( $result ) ) {
+			// translators: %d is the number of posts found
 			\WP_CLI::success( sprintf( __( 'Found %d post(s)', 'block-catalog' ), $result ) );
 		} else {
 			\WP_CLI::warning( __( 'No posts found.', 'block-catalog' ) );

--- a/includes/classes/PostFinder.php
+++ b/includes/classes/PostFinder.php
@@ -105,9 +105,9 @@ class PostFinder {
 		}
 
 		$query_params = [
-			'post_type'      => ! empty( $opts['post_type'] ) ? $opts['post_type'] : \BlockCatalog\Utility\get_supported_post_types(),
-			'post_status'    => ! empty( $opts['post_status'] ) ? $opts['post_status'] : 'any',
-			'tax_query'      => [
+			'post_type'   => ! empty( $opts['post_type'] ) ? $opts['post_type'] : \BlockCatalog\Utility\get_supported_post_types(),
+			'post_status' => ! empty( $opts['post_status'] ) ? $opts['post_status'] : 'any',
+			'tax_query'   => [
 				[
 					'taxonomy' => BLOCK_CATALOG_TAXONOMY,
 					'field'    => 'slug',

--- a/includes/classes/PostFinder.php
+++ b/includes/classes/PostFinder.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * PostFinder
+ *
+ * @package BlockCatalog
+ */
+
+namespace BlockCatalog;
+
+/**
+ * PostFinder searches for posts that have a specific block.
+ */
+class PostFinder {
+
+	/**
+	 * Find posts that have a specific block.
+	 *
+	 * opts can contain:
+	 * - post_type: post type to search for.
+	 * - post_status: post status to search for.
+	 * - posts_per_page: maximum number of posts to return.
+	 * - operator: query operator to use in the search.
+	 *
+	 * @param array $opts Options for the search.
+	 * @return array
+	 */
+	public function find( $blocks, $opts = [] ) {
+		if ( ! $this->is_indexed() ) {
+			return new \WP_Error(
+				'not-indexed',
+				__( 'Block Catalog index is empty, please index the site first.', 'block-catalog' )
+			);
+		}
+
+		$slugs = $this->get_tax_query_terms( $blocks );
+
+		if ( empty( $slugs ) ) {
+			return [];
+		}
+
+		$query_params = [
+			'post_type'      => ! empty( $opts['post_type'] ) ? $opts['post_type'] : \BlockCatalog\Utility\get_supported_post_types(),
+			'post_status'    => ! empty( $opts['post_status'] ) ? $opts['post_status'] : 'any',
+			'posts_per_page' => ! empty( $opts['posts_per_page'] ) ? $opts['posts_per_page'] : 10,
+			'tax_query'      => [
+				[
+					'taxonomy' => BLOCK_CATALOG_TAXONOMY,
+					'field'    => 'slug',
+					'terms'    => $slugs,
+					'operator' => ! empty( $opts['operator'] ) ? $opts['operator'] : 'IN',
+				],
+			],
+		];
+
+		$query = new \WP_Query( $query_params );
+		$posts = $query->posts;
+
+		return $posts;
+	}
+
+	/**
+	 * Find posts that have a specific block on a multisite network.
+	 *
+	 * @param array $sites Sites to search.
+	 * @param array $opts Options for the search.
+	 * @return array
+	 */
+	public function find_on_network( $sites = [], $blocks = [], $opts = [] ) {
+		$found_posts = [];
+
+		foreach ( $sites as $blog_id ) {
+			switch_to_blog( $blog_id );
+
+			$found_on_site = $this->find( $blocks, $opts );
+
+			$result = [
+				'blog_id'  => $blog_id,
+				'blog_url' => get_site_url( $blog_id ),
+				'posts'    => ! is_wp_error( $found_on_site ) ? $found_on_site : [],
+			];
+
+			if ( is_wp_error( $found_on_site ) ) {
+				$result['error'] = $found_on_site;
+			}
+
+			$found_posts[] = $result;
+
+			restore_current_blog();
+		}
+
+		return $found_posts;
+	}
+
+	/**
+	 * Count posts that have a specific block.
+	 *
+	 * @param array $opts Options for the search.
+	 * @return int Total number of posts.
+	 */
+	public function count( $blocks = [], $opts = [] ) {
+		$slugs = $this->get_tax_query_terms( $blocks );
+
+		if ( empty( $slugs ) ) {
+			return 0;
+		}
+
+		$query_params = [
+			'post_type'      => ! empty( $opts['post_type'] ) ? $opts['post_type'] : \BlockCatalog\Utility\get_supported_post_types(),
+			'post_status'    => ! empty( $opts['post_status'] ) ? $opts['post_status'] : 'any',
+			'tax_query'      => [
+				[
+					'taxonomy' => BLOCK_CATALOG_TAXONOMY,
+					'field'    => 'slug',
+					'terms'    => $slugs,
+					'operator' => ! empty( $opts['operator'] ) ? $opts['operator'] : 'IN',
+				],
+			],
+		];
+
+		$query = new \WP_Query( $query_params );
+
+		return $query->found_posts;
+	}
+
+	/**
+	 * Count posts that have a specific block on a multisite network.
+	 *
+	 * @param array $sites Sites to search.
+	 * @param array $opts Options for the search.
+	 * @return int Total number of posts.
+	 */
+	public function count_on_network( $sites = [], $blocks = [], $opts = [] ) {
+		$found_posts = [];
+
+		foreach ( $sites as $blog_id ) {
+			switch_to_blog( $blog_id );
+
+			$found_on_site = $this->count( $blocks, $opts );
+			$found_posts[] = [
+				'blog_id'  => $blog_id,
+				'blog_url' => get_site_url( $blog_id ),
+				'count'    => $found_on_site,
+			];
+
+			restore_current_blog();
+		}
+
+		return $found_posts;
+	}
+
+	/**
+	 * Converts the search query terms like 'core/block' into slugs like 'core-block'.
+	 *
+	 * @param array $args Query terms.
+	 * @return array
+	 */
+	public function get_tax_query_terms( $args = [] ) {
+		$slugs = [];
+
+		foreach ( $args as $index => $arg ) {
+			$slug      = sanitize_title( $arg );
+			$slug_term = get_term_by( 'slug', $slug, BLOCK_CATALOG_TAXONOMY );
+
+			/**
+			 * Filters the slug term for a block query.
+			 *
+			 * @param string|false $slug      The slug for the block.
+			 * @param string       $arg       The original argument.
+			 * @param WP_Term|false $slug_term The term for the slug.
+			 * @return string|false
+			 */
+			$slug_term = apply_filters( 'block_catalog_block_query_slug', $slug_term, $arg );
+
+			if ( false !== $slug_term ) {
+				$slugs[] = $slug;
+			}
+		}
+
+		$slugs = array_values( $slugs );
+		$slugs = array_unique( $slugs );
+
+		return $slugs;
+	}
+
+	/**
+	 * Checks if the Block Catalog taxonomy is indexed.
+	 *
+	 * @return bool
+	 */
+	public function is_indexed() {
+		$catalog_terms = wp_count_terms(
+			[
+				'taxonomy'   => BLOCK_CATALOG_TAXONOMY,
+				'hide_empty' => false,
+			]
+		);
+
+		return ! empty( $catalog_terms );
+	}
+
+}

--- a/includes/classes/PostFinder.php
+++ b/includes/classes/PostFinder.php
@@ -21,6 +21,7 @@ class PostFinder {
 	 * - posts_per_page: maximum number of posts to return.
 	 * - operator: query operator to use in the search.
 	 *
+	 * @param array $blocks Blocks to search for.
 	 * @param array $opts Options for the search.
 	 * @return array
 	 */
@@ -62,6 +63,7 @@ class PostFinder {
 	 * Find posts that have a specific block on a multisite network.
 	 *
 	 * @param array $sites Sites to search.
+	 * @param array $blocks Blocks to search for.
 	 * @param array $opts Options for the search.
 	 * @return array
 	 */
@@ -94,6 +96,7 @@ class PostFinder {
 	/**
 	 * Count posts that have a specific block.
 	 *
+	 * @param array $blocks Blocks to search for.
 	 * @param array $opts Options for the search.
 	 * @return int Total number of posts.
 	 */
@@ -126,6 +129,7 @@ class PostFinder {
 	 * Count posts that have a specific block on a multisite network.
 	 *
 	 * @param array $sites Sites to search.
+	 * @param array $blocks Blocks to search for.
 	 * @param array $opts Options for the search.
 	 * @return int Total number of posts.
 	 */

--- a/includes/core.php
+++ b/includes/core.php
@@ -163,7 +163,7 @@ function script_url( $script, $context ) {
 		return new WP_Error( 'invalid_enqueue_context', 'Invalid $context specified in BlockCatalog script loader.' );
 	}
 
-	return BLOCK_CATALOG_PLUGIN_URL . "dist/js/${script}.js";
+	return BLOCK_CATALOG_PLUGIN_URL . "dist/js/{$script}.js";
 
 }
 
@@ -181,7 +181,7 @@ function style_url( $stylesheet, $context ) {
 		return new WP_Error( 'invalid_enqueue_context', __( 'Invalid $context specified in BlockCatalog stylesheet loader.', 'block-catalog' ) );
 	}
 
-	return BLOCK_CATALOG_PLUGIN_URL . "dist/css/${stylesheet}.css";
+	return BLOCK_CATALOG_PLUGIN_URL . "dist/css/{$stylesheet}.css";
 
 }
 

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Block Catalog
  * Description:       Easily keep track of which Gutenberg Blocks are used across your site.
- * Version:           1.4.0
+ * Version:           1.5.0
  * Requires at least: 5.7
  * Requires PHP:      7.4
  * Author:            Darshan Sawardekar, 10up

--- a/plugin.php
+++ b/plugin.php
@@ -21,6 +21,7 @@ define( 'BLOCK_CATALOG_PLUGIN_VERSION', '1.4.0' );
 define( 'BLOCK_CATALOG_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'BLOCK_CATALOG_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'BLOCK_CATALOG_PLUGIN_INC', BLOCK_CATALOG_PLUGIN_PATH . 'includes/' );
+define( 'BLOCK_CATALOG_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 
 define( 'BLOCK_CATALOG_TAXONOMY', 'block-catalog' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      dsawardekar, 10up
 Tags:              gutenberg, developer, blocks, custom blocks
 Requires at least: 5.7
-Tested up to:      6.1
+Tested up to:      6.2.2
 Requires PHP:      7.4
 Stable tag:        1.4.0
 License:           GPLv2 or later

--- a/tests/classes/PostFinderTest.php
+++ b/tests/classes/PostFinderTest.php
@@ -1,0 +1,441 @@
+<?php
+
+namespace BlockCatalog;
+
+class PostFinderTest extends \WP_UnitTestCase {
+
+	public $finder;
+	public $builder;
+
+	function setUp() {
+		parent::setUp();
+
+		$this->finder  = new PostFinder();
+		$this->builder = new CatalogBuilder();
+	}
+
+	function test_it_can_be_instantiated() {
+		$this->assertInstanceOf( PostFinder::class, $this->finder );
+	}
+
+	function test_it_will_exclude_search_terms_that_dont_have_terms() {
+		// create the core/block term
+		$this->factory->term->create( [
+			'taxonomy' => BLOCK_CATALOG_TAXONOMY,
+			'slug'     => 'core-block',
+		] );
+
+		$actual = $this->finder->get_tax_query_terms( [ 'core/block', 'xyz/no-such-block' ] );
+
+		$this->assertEquals( [ 'core-block' ], $actual );
+	}
+
+	function test_it_can_build_list_of_slugs_from_block_queries() {
+		$this->factory->term->create( [
+			'taxonomy' => BLOCK_CATALOG_TAXONOMY,
+			'slug'     => 'core-block',
+		] );
+
+		$this->factory->term->create( [
+			'taxonomy' => BLOCK_CATALOG_TAXONOMY,
+			'slug'     => 'core-paragraph',
+		] );
+
+		$query  = [ 'core/block', 'core/paragraph' ];
+		$actual = $this->finder->get_tax_query_terms( $query );
+
+		$this->assertEquals( [ 'core-block', 'core-paragraph' ], $actual );
+	}
+
+	function test_it_can_count_posts_with_a_specific_block_on_a_site() {
+		$this->factory->post->create_many( 3, [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+		] );
+
+		$post_ids = $this->factory->post->create_many( 5, [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_content' => '<!-- wp:core/paragraph -->',
+		] );
+
+		$builder = new CatalogBuilder();
+
+		foreach ( $post_ids as $post_id ) {
+			$builder->catalog( $post_id );
+		}
+
+		$actual = $this->finder->count( [ 'core/paragraph' ], [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+		] );
+
+		$this->assertEquals( 5, $actual );
+	}
+
+	function test_it_can_count_posts_with_a_specific_block_on_a_site_across_post_types() {
+		$post_ids = $this->factory->post->create_many( 3, [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_content' => '<!-- wp:core/paragraph -->',
+		] );
+
+		$post_ids = array_merge( $post_ids, $this->factory->post->create_many( 5, [
+			'post_type' => 'page',
+			'post_status' => 'publish',
+			'post_content' => '<!-- wp:core/paragraph -->',
+		] ) );
+
+		$builder = new CatalogBuilder();
+
+		foreach ( $post_ids as $post_id ) {
+			$builder->catalog( $post_id );
+		}
+
+		$actual = $this->finder->count( [ 'core/paragraph' ], [
+			'post_type' => [ 'post', 'page' ],
+			'post_status' => 'publish',
+		] );
+
+		$this->assertEquals( 8, $actual );
+	}
+
+	function test_it_can_count_posts_on_site_using_and_operator() {
+		$post_ids = $this->factory->post->create_many( 2, [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_content' => '<!-- wp:core/button --><!-- /wp:core/button --><!-- wp:core/paragraph --><!-- /wp:core/paragraph -->',
+		] );
+
+		$post_ids = array_merge( $post_ids, $this->factory->post->create_many( 4, [
+			'post_type' => 'page',
+			'post_status' => 'publish',
+			'post_content' => '<!-- wp:core/paragraph -->',
+		] ) );
+
+		$builder = new CatalogBuilder();
+
+		foreach ( $post_ids as $post_id ) {
+			$builder->catalog( $post_id );
+		}
+
+		$actual = $this->finder->count( [ 'core/button', 'core/paragraph' ], [
+			'post_type' => [ 'post', 'page' ],
+			'post_status' => 'publish',
+			'operator' => 'AND',
+		] );
+
+		$this->assertEquals( 2, $actual );
+	}
+
+	function test_it_can_count_posts_on_site_using_or_operator() {
+		$post_ids = $this->factory->post->create_many( 4, [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_content' => '<!-- wp:core/button --><!-- /wp:core/button --><!-- wp:core/paragraph --><!-- /wp:core/paragraph -->',
+		] );
+
+		$post_ids = array_merge( $post_ids, $this->factory->post->create_many( 7, [
+			'post_type' => 'page',
+			'post_status' => 'publish',
+			'post_content' => '<!-- wp:core/paragraph -->',
+		] ) );
+
+		$builder = new CatalogBuilder();
+
+		foreach ( $post_ids as $post_id ) {
+			$builder->catalog( $post_id );
+		}
+
+		$actual = $this->finder->count( [ 'core/button', 'core/paragraph' ], [
+			'post_type' => [ 'post', 'page' ],
+			'post_status' => 'publish',
+			'operator' => 'OR',
+		] );
+
+		$this->assertEquals( 11, $actual );
+	}
+
+	function test_it_can_count_posts_on_site_using_not_in_operator() {
+		$post_ids = $this->factory->post->create_many( 4, [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_content' => '<!-- wp:core/button --><!-- /wp:core/button -->',
+		] );
+
+		$post_ids = array_merge( $post_ids, $this->factory->post->create_many( 6, [
+			'post_type' => 'page',
+			'post_status' => 'publish',
+			'post_content' => '<!-- wp:core/paragraph -->',
+		] ) );
+
+		$builder = new CatalogBuilder();
+
+		foreach ( $post_ids as $post_id ) {
+			$builder->catalog( $post_id );
+		}
+
+		$actual = $this->finder->count( [ 'core/paragraph' ], [
+			'post_type' => [ 'post', 'page' ],
+			'post_status' => 'publish',
+			'operator' => 'NOT IN',
+		] );
+
+		$this->assertEquals( 4, $actual );
+	}
+
+	function test_it_can_count_posts_across_network() {
+		// first create a few blogs on the network
+		$blog_ids = $this->factory->blog->create_many( 3 );
+
+		// create a few posts on each blog
+		foreach ( $blog_ids as $blog_id ) {
+			switch_to_blog( $blog_id );
+
+			$this->factory->post->create_many( 3, [
+				'post_type' => 'post',
+				'post_status' => 'publish',
+				'post_content' => '<!-- wp:core/paragraph -->',
+			] );
+
+			restore_current_blog();
+		}
+
+		// now count on the network
+		$actual = $this->finder->count_on_network( $blog_ids, [ 'core/paragraph' ], [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+		] );
+
+		$this->assertEquals( 3, $actual[0]['count'] );
+		$this->assertEquals( 3, $actual[1]['count'] );
+		$this->assertEquals( 3, $actual[2]['count'] );
+	}
+
+	function test_it_can_count_posts_across_post_types_across_network() {
+		// first create a few blogs on the network
+		$blog_ids = $this->factory->blog->create_many( 3 );
+
+		// create a few posts on each blog
+		foreach ( $blog_ids as $blog_id ) {
+			switch_to_blog( $blog_id );
+
+			$this->factory->post->create_many( 2, [
+				'post_type' => 'post',
+				'post_status' => 'publish',
+				'post_content' => '<!-- wp:core/paragraph -->',
+			] );
+
+			$this->factory->post->create_many( 5, [
+				'post_type' => 'page',
+				'post_status' => 'publish',
+				'post_content' => '<!-- wp:core/paragraph -->',
+			] );
+
+			restore_current_blog();
+		}
+
+		// now count on the network
+		$actual = $this->finder->count_on_network( $blog_ids, [ 'core/paragraph' ], [
+			'post_type' => [ 'post', 'page' ],
+			'post_status' => 'publish',
+		] );
+
+		$this->assertEquals( 7, $actual[0]['count'] );
+		$this->assertEquals( 7, $actual[1]['count'] );
+		$this->assertEquals( 7, $actual[2]['count'] );
+	}
+
+	function test_it_can_find_posts_with_mixed_blocks_across_network() {
+		// first create a few blogs on the network
+		$blog_ids = $this->factory->blog->create_many( 3 );
+
+		// create a few posts on each blog
+		foreach ( $blog_ids as $blog_id ) {
+			switch_to_blog( $blog_id );
+
+			$this->factory->post->create_many( 2, [
+				'post_type' => 'post',
+				'post_status' => 'publish',
+				'post_content' => '<!-- wp:core/paragraph --><!-- /wp:core/paragraph --><!-- wp:core/button --><!-- /wp:core/button -->',
+			] );
+
+			$this->factory->post->create_many( 5, [
+				'post_type' => 'page',
+				'post_status' => 'publish',
+				'post_content' => '<!-- wp:core/paragraph --><!-- /wp:core/paragraph -->',
+			] );
+
+			restore_current_blog();
+		}
+
+		// now count on the network
+		$actual = $this->finder->count_on_network( $blog_ids, [ 'core/paragraph', 'core/button' ], [
+			'post_type' => [ 'post', 'page' ],
+			'post_status' => 'publish',
+			'operator' => 'AND',
+		] );
+
+		$this->assertEquals( 2, $actual[0]['count'] );
+		$this->assertEquals( 2, $actual[1]['count'] );
+		$this->assertEquals( 2, $actual[2]['count'] );
+	}
+
+	function test_it_knows_if_no_block_matches_across_the_network() {
+		// first create a few blogs on the network
+		$blog_ids = $this->factory->blog->create_many( 3 );
+
+		// create a few posts on each blog
+		foreach ( $blog_ids as $blog_id ) {
+			switch_to_blog( $blog_id );
+
+			$this->factory->post->create_many( 2, [
+				'post_type' => 'post',
+				'post_status' => 'publish',
+				'post_content' => '<!-- wp:core/paragraph --><!-- /wp:core/paragraph --><!-- wp:core/button --><!-- /wp:core/button -->',
+			] );
+
+			$this->factory->post->create_many( 5, [
+				'post_type' => 'page',
+				'post_status' => 'publish',
+				'post_content' => '<!-- wp:core/paragraph --><!-- /wp:core/paragraph -->',
+			] );
+
+			restore_current_blog();
+		}
+
+		// now count on the network
+		$actual = $this->finder->count_on_network( $blog_ids, [ 'core/heading' ], [
+			'post_type' => [ 'post', 'page' ],
+			'post_status' => 'publish',
+			'operator' => 'AND',
+		] );
+
+		$this->assertEquals( 0, $actual[0]['count'] );
+		$this->assertEquals( 0, $actual[1]['count'] );
+		$this->assertEquals( 0, $actual[2]['count'] );
+	}
+
+	function test_it_can_find_blocks_on_single_site() {
+		// create a few posts on the blog
+		$post_ids = $this->factory->post->create_many( 2, [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_content' => '<!-- wp:core/paragraph --><!-- /wp:core/paragraph -->',
+		] );
+
+		$actual = $this->finder->find( [ 'core/paragraph' ], [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+		] );
+
+		$actual = array_map( function( $post ) {
+			return $post->ID;
+		}, $actual );
+
+		$this->assertContains( $post_ids[0], $actual );
+		$this->assertContains( $post_ids[1], $actual );
+	}
+
+	function test_it_can_find_blocks_with_operators_on_single_site() {
+		// create posts with core/paragraphs only
+		$this->factory->post->create_many( 2, [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_content' => '<!-- wp:core/paragraph --><!-- /wp:core/paragraph -->',
+		] );
+
+		// create posts with core/paragraphs and core/buttons
+		$post_ids = $this->factory->post->create_many( 2, [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_content' => '<!-- wp:core/paragraph --><!-- /wp:core/paragraph --><!-- wp:core/button --><!-- /wp:core/button -->',
+		] );
+
+		$actual = $this->finder->find( [ 'core/paragraph', 'core/button' ], [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'operator' => 'AND',
+		] );
+
+		$actual = array_map( function( $post ) {
+			return $post->ID;
+		}, $actual );
+
+		// normalize the 2 arrays
+		sort( $post_ids );
+		sort( $actual );
+
+		$this->assertEquals( $post_ids, $actual );
+	}
+
+	function test_it_can_find_posts_across_post_types_with_operators_across_network() {
+		// first create a few blogs on the network
+		$blog_ids = $this->factory->blog->create_many( 3 );
+		$post_ids = [];
+
+		// create a few posts on each blog
+		foreach ( $blog_ids as $blog_id ) {
+			switch_to_blog( $blog_id );
+
+			$post_ids = array_merge( $post_ids, $this->factory->post->create_many( 2, [
+				'post_type' => 'post',
+				'post_status' => 'publish',
+				'post_content' => '<!-- wp:core/paragraph --><!-- /wp:core/paragraph --><!-- wp:core/button --><!-- /wp:core/button -->',
+			] ) );
+
+			$this->factory->post->create_many( 5, [
+				'post_type' => 'page',
+				'post_status' => 'publish',
+				'post_content' => '<!-- wp:core/paragraph --><!-- /wp:core/paragraph -->',
+			] );
+
+			restore_current_blog();
+		}
+
+		// now count on the network
+		$actual = $this->finder->find_on_network( $blog_ids, [ 'core/paragraph', 'core/button' ], [
+			'post_type' => [ 'post', 'page' ],
+			'post_status' => 'publish',
+			'operator' => 'AND',
+		] );
+
+		$this->assertEquals( 2, count( $actual[0]['posts'] ) );
+		$this->assertEquals( 2, count( $actual[1]['posts'] ) );
+		$this->assertEquals( 2, count( $actual[2]['posts'] ) );
+	}
+
+	function test_it_knows_if_site_is_not_indexed() {
+		$this->assertFalse( $this->finder->is_indexed() );
+	}
+
+	function test_it_knows_if_site_is_indexed() {
+		$this->factory->post->create_many( 2, [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_content' => '<!-- wp:core/paragraph --><!-- /wp:core/paragraph -->',
+		] );
+
+		$this->assertTrue( $this->finder->is_indexed() );
+	}
+
+	function test_it_returns_error_if_find_is_called_with_empty_index() {
+		$actual = $this->finder->find( [ 'core/paragraph' ], );
+		$this->assertEquals( 'not-indexed', $actual->get_error_code() );
+	}
+
+	function test_it_returns_list_of_errors_if_finding_fails_across_network() {
+		// create a few blogs on the network
+		$blog_ids = $this->factory->blog->create_many( 3 );
+
+		$actual = $this->finder->find_on_network( $blog_ids, [ 'core/paragraph' ], [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+		] );
+
+		$this->assertEquals( 'not-indexed', $actual[0]['error']->get_error_code() );
+		$this->assertEquals( 'not-indexed', $actual[1]['error']->get_error_code() );
+		$this->assertEquals( 'not-indexed', $actual[2]['error']->get_error_code() );
+	}
+
+}


### PR DESCRIPTION
### Description of the Change

This PR adds support for Multisite WordPress installations via the WP CLI commands. 

* The `find` command now supports a `--network` option
* The `index` command also supports a `--network` option
* The `delete-index` command also supports a `--network` option

The `--network` option will iterate over all the sites on a Multisite install. It also accepts a comma delimited list of `site_ids` to limit the operation to subset of sites, eg:- `--network=1,2`.

![image](https://github.com/10up/block-catalog/assets/3541543/42f7df5c-9f66-4d8f-bd68-e5bb7b41b67f)

You can also combine the `--network` option with the `--count` option to get a summary of a block's usage across the network.

![image](https://github.com/10up/block-catalog/assets/3541543/8c412f90-f928-4b84-adf9-aeeae8b620eb)


### How to test the Change

* Pull this branch locally
* Network activate the block-catalog plugin on a Multisite install
* Run the index with `wp block-catalog index --network`
* Search for blocks across the network

### Changelog Entry

Added - Multisite Support via WP CLI with the --network option


### Credits

Props @dsawardekar 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
