### PR TITLE
Bump WordPress "tested up to" version 6.4

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      10up, dsawardekar, dkotter, jeffpaul
 Tags:              gutenberg, developer, blocks, custom blocks
 Requires at least: 5.7
-Tested up to:      6.3
+Tested up to:      6.4
 Requires PHP:      7.4
 Stable tag:        1.5.1
 License:           GPLv2 or later


### PR DESCRIPTION
Ports #28 to `trunk` in hopes of triggering the WordPress.org Readme Updater to deploy changes to dotorg.