### PR TITLE
Feature/detect classic editor posts

### DIFF
--- a/includes/classes/CatalogBuilder.php
+++ b/includes/classes/CatalogBuilder.php
@@ -317,6 +317,11 @@ class CatalogBuilder {
 		$output = [];
 
 		foreach ( $blocks as $block ) {
+			// change null blocks to classic editor blocks if matched
+			if ( $this->is_classic_editor_block( $block ) ) {
+				$block['blockName'] = 'core/classic';
+			}
+
 			// ignore empty blocks
 			if ( empty( $block['blockName'] ) ) {
 				continue;
@@ -516,5 +521,40 @@ class CatalogBuilder {
 		}
 
 		return intval( $result->term_id );
+	}
+
+	/**
+	 * Checks if block is a classic editor block
+	 *
+	 * @param array $block The block data
+	 * @return boolean
+	 */
+	public function is_classic_editor_block( $block ) {
+		if ( empty( $block ) ) {
+			return false;
+		}
+
+		// if block has a name, it's not a classic editor block
+		if ( ! is_null( $block['blockName'] ) ) {
+			return false;
+		}
+
+		$allowed_tags = array_keys( wp_kses_allowed_html( 'post' ) );
+
+		$inner_html = $block['innerHTML'] ?? '';
+		$inner_html = trim( $inner_html );
+
+		if ( empty( $inner_html ) ) {
+			return false;
+		}
+
+		// if inner_html has any of the allowed tags, it's a classic editor block
+		foreach ( $allowed_tags as $tag ) {
+			if ( strpos( $inner_html, "<{$tag}" ) !== false ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/tests/classes/CatalogBuilderTest.php
+++ b/tests/classes/CatalogBuilderTest.php
@@ -409,4 +409,90 @@ class CatalogBuilderTest extends \WP_UnitTestCase {
 		$this->assertEmpty( $actual );
 	}
 
+	function test_it_knows_core_paragraph_is_not_classic_editor() {
+		$block = [
+			'blockName' => 'core/paragraph',
+		];
+
+		$this->assertFalse( $this->builder->is_classic_editor_block( $block ) );
+	}
+
+	function test_it_knows_untitled_html_is_classic_editor() {
+		$block = [
+			'blockName' => null,
+			'innerHTML' => '<p>Some HTML</p>',
+		];
+
+		$this->assertTrue( $this->builder->is_classic_editor_block( $block ) );
+	}
+
+	function test_it_does_not_have_classic_editor_in_terms_if_only_gutenberg() {
+		$post_content = <<<HTML
+<!-- wp:paragraph -->
+<p>Paragraph</p>
+<!-- /wp:paragraph -->
+<!-- wp:image -->
+<figure class="wp-block-image"><img src="https://example.com/image.jpg" alt="Image" /></figure>
+<!-- /wp:image -->
+HTML;
+
+		$post_id			= $this->factory->post->create( [ 'post_content' => $post_content ] );
+		$post_terms   = [
+			'core/paragraph' => 'Paragraph',
+			'core/image' => 'Image',
+		];
+
+		$actual = $this->builder->get_post_block_terms( $post_id );
+
+		$this->assertEquals( $post_terms, $actual['terms'] );
+	}
+
+	function test_it_has_classic_editor_in_terms_with_variation_1() {
+		$post_content = <<<HTML
+<p>
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio.
+  Ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio.
+</p>
+<hr />
+<!-- wp:image {"sizeSlug":"large","className":"is-style-default"} -->
+<figure class="wp-block-image size-large is-style-default">
+  <img
+    src="https://example.com/image.jpg"
+    alt=""
+  />
+</figure>
+<!-- /wp:image -->
+
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+<p>
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio.
+	Ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio.
+</p>
+<p>
+ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio.
+</p>
+
+<!-- wp:image {"sizeSlug":"large","className":"is-style-default"} -->
+<figure class="wp-block-image size-large is-style-default">
+  <img
+    src="https://example.com/image-2.jpg"
+    alt=""
+  />
+</figure>
+<!-- /wp:image -->
+
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+<p>
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio.
+	Ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio.
+</p>
+HTML;
+		$post_id = $this->factory->post->create( [ 'post_content' => $post_content ] );
+		$actual  = $this->builder->get_post_block_terms( $post_id );
+
+		$this->assertEquals( 'Classic', $actual['terms']['core/classic'] );
+	}
+
+
 }


### PR DESCRIPTION
### Description of the Change

This PR adds support for detecting Classic Editor blocks mixed with Gutenberg Blocks. This allows Block Catalog to find both legacy Classic Editor posts and posts that have other Gutenberg blocks alongside Classic Editor content.

### How to test the Change

Run the Block Catalog index with content that uses Classic Editor or has hybrid content. Or view the blocks for a post via CLI. You should see a Core > Classic block for that post in the block catalog taxonomy.

Output for a Classic Editor Post & a Hybrid Post:
![image](https://github.com/10up/block-catalog/assets/3541543/7baccd07-ee47-4da9-8573-62cdd8bb10ac)

![image](https://github.com/10up/block-catalog/assets/3541543/a4f83583-fe5c-4d81-ac6d-1593434bf1b8)

### Changelog Entry

Added - Classic Editor block detection

### Credits

Props @dsawardekar 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
