### PR TITLE
Bump WordPress "tested up to" version 6.6

### DIFF
--- a/block-catalog.php
+++ b/block-catalog.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Block Catalog
  * Description:       Easily keep track of which Gutenberg Blocks are used across your site.
  * Version:           1.6.0
- * Requires at least: 6.3
+ * Requires at least: 6.4
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Block Catalog ===
 Contributors:      10up, dsawardekar, dkotter, jeffpaul
 Tags:              gutenberg, developer, blocks, custom blocks
-Tested up to:      6.5
+Tested up to:      6.6
 Stable tag:        1.6.0
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR bumps the WP tested-up-to 6.6 and the minimum to 6.4.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #59.

### How to test the Change
Use Plugin ZIP action to get version from this PR and run through critical flows, otherwise review results of e2e tests.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Bump WordPress "tested up to" version 6.6.
> Changed - Bump WordPress minimum supported version to 6.4.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @sudip-md, @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
