### PR TITLE
Change importFile to importWxr in blueprint.json

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -13,7 +13,7 @@
 			"password": "password"
 		},
 		{
-			"step": "importFile",
+			"step": "importWxr",
 			"file": {
 				"resource": "url",
 				"url": "https:\/\/raw.githubusercontent.com\/Automattic\/theme-tools\/4eb4a1abf194d83c540b9172b7d15ca65622c097\/gutenberg-test-data\/gutenberg-test-data.xml"


### PR DESCRIPTION
### Description of the Change

importFile step is deprecated, use importWxr instead:

- https://github.com/WordPress/wordpress-playground/blob/5ab019693719b6fae78014aa583cfeb652528e6d/CHANGELOG.md?plain=1#L877
- https://wordpress.github.io/wordpress-playground/blueprints/steps/#ImportWxrStep