### PR TITLE
Use cross system bash interpreter.

### DIFF
--- a/bin/build-release-svn.sh
+++ b/bin/build-release-svn.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 rsync \
 	-av \

--- a/bin/build-release-zip.sh
+++ b/bin/build-release-zip.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 version=$1
 file=block-catalog-$version.zip


### PR DESCRIPTION
Modifies the bash interpreter in the release scripts to use the generic `#!/usr/bin/env bash` instead of the specific `#!/bin/bash?`

The former searches the `$PATH` for the bash shell while the current code assumes the location.

For an explanation, see https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash

Closes #82

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Developer - Use cross system bash interpreter, `#!/usr/bin/env bash`.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
