### PR TITLE
Bump require at least wordpress version 6.6

### DIFF
--- a/block-catalog.php
+++ b/block-catalog.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Block Catalog
  * Description:       Keep track of which Gutenberg Blocks are used across your site.
  * Version:           1.6.2
- * Requires at least: 6.5
+ * Requires at least: 6.6
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com

--- a/tests/classes/CatalogBuilderTest.php
+++ b/tests/classes/CatalogBuilderTest.php
@@ -212,7 +212,7 @@ class CatalogBuilderTest extends \WP_UnitTestCase {
 			'core/column'    => 'Column',
 			'core/columns'   => 'Columns',
 			'core/list'      => 'List',
-			'core/list-item' => 'List item',
+			'core/list-item' => 'List Item',
 			'core/paragraph' => 'Paragraph',
 			'core/quote'     => 'Quote',
 		];
@@ -272,7 +272,7 @@ class CatalogBuilderTest extends \WP_UnitTestCase {
 		$this->assertContains( 'Column', $actual );
 		$this->assertContains( 'Columns', $actual );
 		$this->assertContains( 'List', $actual );
-		$this->assertContains( 'List item', $actual );
+		$this->assertContains( 'List Item', $actual );
 		$this->assertContains( 'Paragraph', $actual );
 		$this->assertContains( 'Quote', $actual );
 		$this->assertContains( 'Core', $actual );

--- a/tests/classes/RESTSupportTest.php
+++ b/tests/classes/RESTSupportTest.php
@@ -51,7 +51,7 @@ class RESTSupportTest extends \WP_UnitTestCase {
 		$this->assertContains( 'Column', $actual );
 		$this->assertContains( 'Columns', $actual );
 		$this->assertContains( 'List', $actual );
-		$this->assertContains( 'List item', $actual );
+		$this->assertContains( 'List Item', $actual );
 		$this->assertContains( 'Paragraph', $actual );
 		$this->assertContains( 'Quote', $actual );
 		$this->assertContains( 'Core', $actual );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #80

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Follow the critical flows to test the PR

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Bump WordPress "require at least" version 6.6




