### PR TITLE
Fix/workflow perms

### DIFF
--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -1,5 +1,8 @@
 name: Build release zip
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,5 +1,8 @@
 name: JS Linting
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -1,4 +1,6 @@
 name: PHP Compatibility
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,5 +1,8 @@
 name: PHP Linting
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -13,6 +13,9 @@ on:
     paths:
       - "**.php"
 
+permissions:
+  contents: read
+
 jobs:
   phpunit:
     runs-on: ubuntu-latest

--- a/.github/workflows/wordpress-plugin-asset-update.yml
+++ b/.github/workflows/wordpress-plugin-asset-update.yml
@@ -1,5 +1,9 @@
 name: Plugin asset/readme update
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     branches:

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   tag:
     name: New release


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This pull request updates several GitHub Actions workflows to explicitly define permissions for improved security and functionality. The changes primarily involve adding `contents: read` permissions across multiple workflows and introducing `pull-requests: write` permissions in one specific workflow.

### Permissions updates for workflows:

* [`.github/workflows/build-release-zip.yml`](diffhunk://#diff-948bce84fd4ffebcbf8f82de6162123178817db71cecfb56a7fa79a9535676ecR3-R5): Added `contents: read` permissions to allow read access to repository contents during the workflow execution.
* [`.github/workflows/eslint.yml`](diffhunk://#diff-8deb4e00ff9e68f9e5e25914b8d329a413bfbc90ab5f8c97662324cc68903d2fR3-R5): Added `contents: read` permissions for JavaScript linting workflow.
* [`.github/workflows/php-compat.yml`](diffhunk://#diff-c97648c65fcba9a1efaa6c7aaa91a3e94dd52f6de7a7d12fce1e54655f8c581eR2-R3): Added `contents: read` permissions for PHP compatibility checks.
* [`.github/workflows/phpcs.yml`](diffhunk://#diff-f621c7ec73ae73c758a64d5f030f2062fc73f50676d953035650636c052aac3fR3-R5): Added `contents: read` permissions for PHP linting workflow.
* [`.github/workflows/phpunit.yml`](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510R16-R18): Added `contents: read` permissions for PHPUnit testing workflow.
* [`.github/workflows/wordpress-plugin-asset-update.yml`](diffhunk://#diff-c3e586c1c6d72ed01af94b58e01c947574f715cca5273395f6d5710d604bcf49R3-R6): Added `contents: read` permissions and `pull-requests: write` permissions to enable plugin asset/readme updates and pull request creation.
* [`.github/workflows/wordpress-plugin-deploy.yml`](diffhunk://#diff-bf57fcc9204204a22da1eb4eae4899a30f5e112b15749bf1577e595d8d1b8d1aR7-R9): Added `contents: read` permissions for WordPress plugin deployment workflow.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

n/a

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
