### PR TITLE
Add "Settings" page link to plugin actions

### DIFF
--- a/block-catalog.php
+++ b/block-catalog.php
@@ -21,6 +21,7 @@ define( 'BLOCK_CATALOG_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'BLOCK_CATALOG_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'BLOCK_CATALOG_PLUGIN_INC', BLOCK_CATALOG_PLUGIN_PATH . 'includes/' );
 define( 'BLOCK_CATALOG_PLUGIN_FILE', plugin_basename( __FILE__ ) );
+define( 'BLOCK_CATALOG_PLUGIN_BASENAME', plugin_basename( __DIR__ . '/block-catalog.php' ) );
 
 define( 'BLOCK_CATALOG_TAXONOMY', 'block-catalog' );
 

--- a/includes/classes/ToolsPage.php
+++ b/includes/classes/ToolsPage.php
@@ -169,8 +169,7 @@ class ToolsPage {
 	 * Add the action links to the plugin page.
 	 *
 	 * @param array $links The Action links for the plugin.
-	 *
-	 * @return array
+	 * @return array Modified action links to include custom link.
 	 */
 	public function filter_plugin_action_links( $links ) {
 

--- a/includes/classes/ToolsPage.php
+++ b/includes/classes/ToolsPage.php
@@ -24,6 +24,7 @@ class ToolsPage {
 	 */
 	public function register() {
 		add_action( 'admin_menu', [ $this, 'register_page' ] );
+		add_filter( 'plugin_action_links_' . BLOCK_CATALOG_PLUGIN_BASENAME, array( $this, 'filter_plugin_action_links' ) );
 	}
 
 	/**
@@ -162,5 +163,30 @@ class ToolsPage {
 				'catalog_page'            => admin_url( 'edit-tags.php?taxonomy=' . BLOCK_CATALOG_TAXONOMY ),
 			],
 		];
+	}
+
+	/**
+	 * Add the action links to the plugin page.
+	 *
+	 * @param array $links The Action links for the plugin.
+	 *
+	 * @return array
+	 */
+	public function filter_plugin_action_links( $links ) {
+
+		if ( ! is_array( $links ) ) {
+			return $links;
+		}
+
+		return array_merge(
+			array(
+				'settings' => sprintf(
+					'<a href="%s"> %s </a>',
+					esc_url( admin_url( 'tools.php?page=block-catalog-tools' ) ),
+					esc_html__( 'Settings', 'block-catalog' )
+				),
+			),
+			$links
+		);
 	}
 }

--- a/includes/classes/ToolsPage.php
+++ b/includes/classes/ToolsPage.php
@@ -179,10 +179,10 @@ class ToolsPage {
 
 		return array_merge(
 			array(
-				'settings' => sprintf(
+				'index-posts' => sprintf(
 					'<a href="%s"> %s </a>',
 					esc_url( admin_url( 'tools.php?page=block-catalog-tools' ) ),
-					esc_html__( 'Settings', 'block-catalog' )
+					esc_html__( 'Index Posts', 'block-catalog' )
 				),
 			),
 			$links


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #72

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Visit `/wp-admin/plugins.php` page of your site.
2. If `Block Catalog` plugin is not active, then activate it.
3. Once it is activated, you should see `Settings` link right below the plugin name, before `Deactivate` link.
4. On clicking on `Settings` link, you should be redirected to `/wp-admin/tools.php?page=block-catalog-tools` page.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - "Settings" page link right on the plugins page to review the settings of the plugin from there directly.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @sanketio

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
