### PR TITLE
Fix Object Cache Pro compatibility issue

### DIFF
--- a/includes/utility.php
+++ b/includes/utility.php
@@ -80,19 +80,12 @@ function clear_caches() {
 
 	$wpdb->queries = array();
 
-	// Clear runtime cache to prevent out of memory errors during bulk operations
-	// wp_cache_flush_runtime() was introduced in WordPress 6.0.0 and is more appropriate for OOM prevention
 	if ( function_exists( 'wp_cache_flush_runtime' ) ) {
 		wp_cache_flush_runtime();
 	} else {
-		// Fallback to wp_cache_flush() for older WordPress versions
-		// wp_cache_flush() has been available since early WordPress versions
-		if ( function_exists( 'wp_cache_flush' ) ) {
-			wp_cache_flush();
-		}
+		wp_cache_flush();
 	}
 	
-	// Reset any custom cache stats if the object cache supports it
 	if ( function_exists( 'wp_cache_stats' ) ) {
 		wp_cache_stats();
 	}

--- a/includes/utility.php
+++ b/includes/utility.php
@@ -82,10 +82,16 @@ function clear_caches() {
 
 	// Use WordPress's built-in cache functions instead of accessing object cache properties directly
 	// This ensures compatibility with all object cache implementations including Object Cache Pro
-
-	// Clear all cache groups
-	wp_cache_flush();
-
+	
+	// Clear runtime cache to prevent out of memory errors during bulk operations
+	// wp_cache_flush_runtime() was introduced in WordPress 6.0.0 and is more appropriate for OOM prevention
+	if ( function_exists( 'wp_cache_flush_runtime' ) ) {
+		wp_cache_flush_runtime();
+	} else {
+		// Fallback to wp_cache_flush() for older WordPress versions
+		wp_cache_flush();
+	}
+	
 	// Reset any custom cache stats if the object cache supports it
 	if ( function_exists( 'wp_cache_stats' ) ) {
 		wp_cache_stats();

--- a/includes/utility.php
+++ b/includes/utility.php
@@ -80,16 +80,16 @@ function clear_caches() {
 
 	$wpdb->queries = array();
 
-	// Use WordPress's built-in cache functions instead of accessing object cache properties directly
-	// This ensures compatibility with all object cache implementations including Object Cache Pro
-	
 	// Clear runtime cache to prevent out of memory errors during bulk operations
 	// wp_cache_flush_runtime() was introduced in WordPress 6.0.0 and is more appropriate for OOM prevention
 	if ( function_exists( 'wp_cache_flush_runtime' ) ) {
 		wp_cache_flush_runtime();
 	} else {
 		// Fallback to wp_cache_flush() for older WordPress versions
-		wp_cache_flush();
+		// wp_cache_flush() has been available since early WordPress versions
+		if ( function_exists( 'wp_cache_flush' ) ) {
+			wp_cache_flush();
+		}
 	}
 	
 	// Reset any custom cache stats if the object cache supports it

--- a/includes/utility.php
+++ b/includes/utility.php
@@ -88,7 +88,6 @@ function clear_caches() {
 		// Fallback to wp_cache_flush() for older WordPress versions or implementations without runtime support
 		wp_cache_flush();
 	}
-
 }
 
 /**

--- a/includes/utility.php
+++ b/includes/utility.php
@@ -76,19 +76,19 @@ function stop_bulk_operation() {
  * @props VIP
  */
 function clear_caches() {
-	global $wpdb, $wp_object_cache;
+	global $wpdb;
 
 	$wpdb->queries = array();
 
-	if ( is_object( $wp_object_cache ) ) {
-		$wp_object_cache->group_ops      = array();
-		$wp_object_cache->stats          = array();
-		$wp_object_cache->memcache_debug = array();
-		$wp_object_cache->cache          = array();
+	// Use WordPress's built-in cache functions instead of accessing object cache properties directly
+	// This ensures compatibility with all object cache implementations including Object Cache Pro
 
-		if ( method_exists( $wp_object_cache, '__remoteset' ) ) {
-			$wp_object_cache->__remoteset(); // important
-		}
+	// Clear all cache groups
+	wp_cache_flush();
+
+	// Reset any custom cache stats if the object cache supports it
+	if ( function_exists( 'wp_cache_stats' ) ) {
+		wp_cache_stats();
 	}
 }
 

--- a/includes/utility.php
+++ b/includes/utility.php
@@ -89,10 +89,6 @@ function clear_caches() {
 		wp_cache_flush();
 	}
 
-	// Reset any custom cache stats if the object cache supports it
-	if ( function_exists( 'wp_cache_stats' ) ) {
-		wp_cache_stats();
-	}
 }
 
 /**

--- a/includes/utility.php
+++ b/includes/utility.php
@@ -88,7 +88,7 @@ function clear_caches() {
 		// Fallback to wp_cache_flush() for older WordPress versions or implementations without runtime support
 		wp_cache_flush();
 	}
-	
+
 	// Reset any custom cache stats if the object cache supports it
 	if ( function_exists( 'wp_cache_stats' ) ) {
 		wp_cache_stats();

--- a/includes/utility.php
+++ b/includes/utility.php
@@ -80,12 +80,16 @@ function clear_caches() {
 
 	$wpdb->queries = array();
 
-	if ( function_exists( 'wp_cache_flush_runtime' ) ) {
+	// Clear runtime cache to prevent out of memory errors during bulk operations
+	// Use wp_cache_supports() to check for runtime flush capability (WordPress 6.0+)
+	if ( function_exists( 'wp_cache_supports' ) && wp_cache_supports( 'flush_runtime' ) ) {
 		wp_cache_flush_runtime();
 	} else {
+		// Fallback to wp_cache_flush() for older WordPress versions or implementations without runtime support
 		wp_cache_flush();
 	}
 	
+	// Reset any custom cache stats if the object cache supports it
 	if ( function_exists( 'wp_cache_stats' ) ) {
 		wp_cache_stats();
 	}

--- a/tests/UtilityTest.php
+++ b/tests/UtilityTest.php
@@ -83,4 +83,18 @@ class UtilityTests extends \WP_UnitTestCase {
 		// If we reach this point, the test passes
 		$this->assertTrue( true );
 	}
+
+	function test_clear_caches_uses_appropriate_cache_function() {
+		// Test that the function uses wp_cache_flush_runtime() when available (WordPress 6.0+)
+		// This is more appropriate for preventing out of memory errors during bulk operations
+		if ( function_exists( 'wp_cache_flush_runtime' ) ) {
+			// We can't easily test the internal behavior without mocking, but we can verify
+			// the function exists and our function can call it without errors
+			$this->assertTrue( function_exists( 'wp_cache_flush_runtime' ) );
+		}
+		
+		// The function should always work regardless of WordPress version
+		$result = clear_caches();
+		$this->assertNull( $result );
+	}
 }

--- a/tests/UtilityTest.php
+++ b/tests/UtilityTest.php
@@ -87,10 +87,11 @@ class UtilityTests extends \WP_UnitTestCase {
 	function test_clear_caches_uses_appropriate_cache_function() {
 		// Test that the function uses wp_cache_flush_runtime() when available (WordPress 6.0+)
 		// This is more appropriate for preventing out of memory errors during bulk operations
-		if ( function_exists( 'wp_cache_flush_runtime' ) ) {
+		if ( function_exists( 'wp_cache_supports' ) && wp_cache_supports( 'flush_runtime' ) ) {
 			// We can't easily test the internal behavior without mocking, but we can verify
-			// the function exists and our function can call it without errors
-			$this->assertTrue( function_exists( 'wp_cache_flush_runtime' ) );
+			// the capability check works and our function can call it without errors
+			$this->assertTrue( function_exists( 'wp_cache_supports' ) );
+			$this->assertTrue( wp_cache_supports( 'flush_runtime' ) );
 		}
 		
 		// The function should always work regardless of WordPress version

--- a/tests/UtilityTest.php
+++ b/tests/UtilityTest.php
@@ -70,4 +70,17 @@ class UtilityTests extends \WP_UnitTestCase {
 
 		$this->assertEquals( 'manage_options', get_required_capability() );
 	}
+
+	function test_clear_caches_does_not_cause_errors() {
+		// Test that clear_caches function can be called without errors
+		// This is especially important for compatibility with Object Cache Pro and other cache implementations
+		$result = clear_caches();
+		
+		// The function should not return anything (void function)
+		$this->assertNull( $result );
+		
+		// The function should not cause any fatal errors or exceptions
+		// If we reach this point, the test passes
+		$this->assertTrue( true );
+	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->
### Description of the Change
- Replace direct access to object cache properties with WordPress's `wp_cache_*` functions
- This fixes the fatal error when using Object Cache Pro or other object cache drop-ins
- Follows WordPress best practices for plugin development
- Add test to ensure clear_caches function works without errors

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #95

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
- Install and activate Object Cache Pro and Block Catalog plugins
- Trigger a block index
- See that indexing occurs without incident

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Fatal error accessing object cache properties that may be protected/private in drop-ins.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @heyjones, @stevenwareham

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [X] I have updated the documentation accordingly.
- [X] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [X] All new and existing tests pass.
