### PR TITLE
Adds Support for Block Patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - Find which blocks are used across your site.
 - Fully Integrated with the WordPress Admin.
 - Use filters to see Posts that use a specific block.
-- Find Posts that use Reusable Blocks.
+- Find Posts that use Block Patterns.
 - Use the WP CLI to quickly find blocks from the command line.
 - Use custom WordPress filters to extend the Block Catalog.
 - Find block usage on a Multisite network.
@@ -107,11 +107,14 @@ The following WP CLI commands are supported by the Block Catalog plugin.
   - [--network=\<network\>]
     Deletes the indexes across the entire network. Accepts a comma delimited list of child site ids.
 
-- `wp block-catalog post-blocks <post-id> [--index]`
-  Prints the list of blocks in the specified post.
+- `wp block-catalog post-blocks <post-id> [--type=<type>]`
+  Prints the blocks and patterns used in the specified post.
 
   - \<post-id\>
-    The post id to lookup blocks for.
+    The post id to look up.
+
+  - [--type=\<type\>]
+    Filter the output by type — `any` (default), `blocks`, or `patterns`.
 
 - `wp block-catalog export [--output=<output>] [--post_type=<types>] [--posts_per_block=<number>] [--ignore_parent=<ignore_parent>]`
   Exports the posts associated with the 'block_catalog' taxonomy to a CSV file.

--- a/includes/classes/CatalogBuilder.php
+++ b/includes/classes/CatalogBuilder.php
@@ -490,6 +490,16 @@ class CatalogBuilder {
 	}
 
 	/**
+	 * Checks if a catalog term slug belongs to a pattern, including synced/reusable patterns.
+	 *
+	 * @param string $slug The term slug
+	 * @return bool
+	 */
+	public function is_pattern_term( $slug ) {
+		return 0 === stripos( $slug, 'pattern-' ) || 0 === stripos( $slug, 're-' );
+	}
+
+	/**
 	 * Finds the label of the block term from its blockName.
 	 *
 	 * @param string $block The block data

--- a/includes/classes/CatalogBuilder.php
+++ b/includes/classes/CatalogBuilder.php
@@ -372,6 +372,8 @@ class CatalogBuilder {
 			$terms[ $block['blockName'] ] = $label;
 		}
 
+		$terms = array_replace( $terms, $this->get_pattern_terms( $block ) );
+
 		/**
 		 * Filters the term labels corresponding to the block in the catalog. This
 		 * is useful to build multiple terms from a single block.
@@ -395,6 +397,96 @@ class CatalogBuilder {
 			'terms'      => $terms,
 			'variations' => $variations,
 		];
+	}
+
+	/**
+	 * Checks if the block originated from a block pattern.
+	 *
+	 * @param array $block The block data
+	 * @return bool
+	 */
+	public function is_pattern_block( $block ) {
+		return ! empty( $block['attrs']['metadata']['patternName'] );
+	}
+
+	/**
+	 * Checks if the pattern name refers to a user pattern, ie:- a wp_block post.
+	 *
+	 * @param string $name The pattern name
+	 * @return bool
+	 */
+	public function is_user_pattern( $name ) {
+		return 0 === stripos( $name, 'core/block/' );
+	}
+
+	/**
+	 * Returns the wp_block post id from a user pattern name.
+	 *
+	 * @param string $name The pattern name, eg:- core/block/1412
+	 * @return int
+	 */
+	public function get_user_pattern_id( $name ) {
+		return intval( substr( $name, strlen( 'core/block/' ) ) );
+	}
+
+	/**
+	 * Converts a block's pattern to a list of term names.
+	 *
+	 * @param array $block The block data
+	 * @return array
+	 */
+	public function get_pattern_terms( $block ) {
+		if ( ! $this->is_pattern_block( $block ) ) {
+			return [];
+		}
+
+		$slug = $this->get_pattern_slug( $block );
+
+		if ( empty( $slug ) ) {
+			return [];
+		}
+
+		return [ $slug => $this->get_pattern_label( $block ) ];
+	}
+
+	/**
+	 * Finds the catalog slug for the block's pattern.
+	 *
+	 * @param array $block The block data
+	 * @return string
+	 */
+	public function get_pattern_slug( $block ) {
+		$name = $block['attrs']['metadata']['patternName'];
+
+		if ( $this->is_user_pattern( $name ) ) {
+			$id = $this->get_user_pattern_id( $name );
+			return ! empty( $id ) ? 'pattern-' . $id : '';
+		}
+
+		return 'pattern-' . sanitize_title( $name );
+	}
+
+	/**
+	 * Finds the display label for the block's pattern.
+	 *
+	 * @param array $block The block data
+	 * @return string
+	 */
+	public function get_pattern_label( $block ) {
+		$name = $block['attrs']['metadata']['patternName'];
+
+		if ( $this->is_user_pattern( $name ) ) {
+			$label = get_the_title( $this->get_user_pattern_id( $name ) );
+		} else {
+			$registered = \WP_Block_Patterns_Registry::get_instance()->get_registered( $name );
+			$label      = ! empty( $registered['title'] ) ? $registered['title'] : '';
+		}
+
+		if ( empty( $label ) ) {
+			$label = $block['attrs']['metadata']['name'] ?? $name;
+		}
+
+		return $label;
 	}
 
 	/**
@@ -453,6 +545,10 @@ class CatalogBuilder {
 	public function get_block_parent_name( $name ) {
 		if ( 0 === stripos( $name, 're-' ) ) {
 			return __( 'Reusable block', 'block-catalog' );
+		}
+
+		if ( 0 === stripos( $name, 'pattern-' ) ) {
+			return __( 'Patterns', 'block-catalog' );
 		}
 
 		$parts     = explode( '/', $name );

--- a/includes/classes/CatalogCommand.php
+++ b/includes/classes/CatalogCommand.php
@@ -179,6 +179,9 @@ class CatalogCommand extends \WP_CLI_Command {
 	 * <post-id>
 	 * : The post id to lookup blocks for.
 	 *
+	 * [--type=<type>]
+	 * : Filter terms by type. One of 'any', 'blocks', 'patterns'. Default 'any'.
+	 *
 	 * @subcommand post-blocks
 	 * @param array $args Command args
 	 * @param array $opts Command opts
@@ -188,28 +191,42 @@ class CatalogCommand extends \WP_CLI_Command {
 			\WP_CLI::error( __( 'Please enter a valid post_id', 'block-catalog' ) );
 		}
 
+		$type = isset( $opts['type'] ) ? $opts['type'] : 'any';
+
+		if ( ! in_array( $type, [ 'any', 'blocks', 'patterns' ], true ) ) {
+			\WP_CLI::error( __( "Invalid --type, expected one of 'any', 'blocks' or 'patterns'.", 'block-catalog' ) );
+		}
+
 		$post_id = intval( $args[0] );
 
 		$builder = new CatalogBuilder();
 		$builder->catalog( $post_id );
 
 		$blocks = wp_get_object_terms( $post_id, BLOCK_CATALOG_TAXONOMY );
+		$blocks = $this->filter_post_blocks( $blocks, $type );
 
 		if ( empty( $blocks ) ) {
-			\WP_CLI::error( __( 'No blocks found.', 'block-catalog' ) );
+			\WP_CLI::error(
+				'patterns' === $type
+					? __( 'No patterns found.', 'block-catalog' )
+					: __( 'No blocks found.', 'block-catalog' )
+			);
 		}
 
+		$name_label = 'patterns' === $type ? 'Pattern Name' : 'Block Name';
+
 		$block_items = array_map(
-			function ( $term ) {
+			function ( $term ) use ( $name_label ) {
 				return [
-					'Block' => $term->name,
-					'ID'    => $term->term_id,
+					'ID'        => $term->term_id,
+					$name_label => $term->name,
+					'Slug'      => $term->slug,
 				];
 			},
 			$blocks
 		);
 
-		\WP_CLI\Utils\format_items( 'table', $block_items, [ 'ID', 'Block' ] );
+		\WP_CLI\Utils\format_items( 'table', $block_items, [ 'ID', $name_label, 'Slug' ] );
 	}
 
 	/**
@@ -257,6 +274,36 @@ class CatalogCommand extends \WP_CLI_Command {
 		} else {
 			\WP_CLI::success( $result['message'] );
 		}
+	}
+
+	/**
+	 * Filters a post's catalog terms by type, dropping grouping parent terms.
+	 *
+	 * @param array  $terms The post's catalog terms
+	 * @param string $type The type filter, one of 'any', 'blocks' or 'patterns'
+	 * @return array
+	 */
+	private function filter_post_blocks( $terms, $type ) {
+		$builder = new CatalogBuilder();
+
+		return array_filter(
+			$terms,
+			function ( $term ) use ( $type, $builder ) {
+				if ( 0 === $term->parent ) {
+					return false;
+				}
+
+				if ( 'patterns' === $type ) {
+					return $builder->is_pattern_term( $term->slug );
+				}
+
+				if ( 'blocks' === $type ) {
+					return ! $builder->is_pattern_term( $term->slug );
+				}
+
+				return true;
+			}
+		);
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -14,6 +14,7 @@ Keep track of which Gutenberg Blocks are used across your site.
 * Fully Integrated with the WordPress Admin.
 * Use filters to see Posts that use a specific block.
 * Find Posts that use Reusable Blocks.
+* Find Posts that use Block Patterns.
 * Use the WP CLI to quickly find blocks from the command line.
 * Use custom WordPress filters to extend the Block Catalog.
 

--- a/tests/classes/CatalogBuilderTest.php
+++ b/tests/classes/CatalogBuilderTest.php
@@ -249,6 +249,19 @@ class CatalogBuilderTest extends \WP_UnitTestCase {
 		$this->assertEquals( $expected, $actual['terms'] );
 	}
 
+	function test_it_knows_pattern_slug_is_a_pattern_term() {
+		$this->assertTrue( $this->builder->is_pattern_term( 'pattern-1412' ) );
+		$this->assertTrue( $this->builder->is_pattern_term( 'pattern-twentytwentyfive-hero' ) );
+	}
+
+	function test_it_treats_reusable_slug_as_a_pattern_term() {
+		$this->assertTrue( $this->builder->is_pattern_term( 're-555' ) );
+	}
+
+	function test_it_knows_block_slug_is_not_a_pattern_term() {
+		$this->assertFalse( $this->builder->is_pattern_term( 'core-paragraph' ) );
+	}
+
 	function test_it_uses_block_label_as_term_for_non_reusable_blocks() {
 		register_block_type( 'ns/foo11', [ 'title' => 'Registered Title' ] );
 

--- a/tests/classes/CatalogBuilderTest.php
+++ b/tests/classes/CatalogBuilderTest.php
@@ -133,6 +133,122 @@ class CatalogBuilderTest extends \WP_UnitTestCase {
 		$this->assertEquals( [ "re-$post_id" => 'My Reusable1' ], $actual['terms'] );
 	}
 
+	function test_it_will_use_patterns_as_parent_for_pattern_terms() {
+		$actual = $this->builder->get_block_parent_name( 'pattern-1412' );
+		$this->assertEquals( 'Patterns', $actual );
+	}
+
+	function test_it_uses_pattern_name_as_term_for_user_pattern() {
+		$post_id = $this->factory->post->create( [ 'post_type' => 'wp_block', 'post_title' => 'Test List Pattern' ] );
+
+		$block = [
+			'blockName' => 'core/list',
+			'attrs'     => [
+				'metadata' => [
+					'patternName' => "core/block/$post_id",
+					'name'        => 'Test List Pattern',
+				],
+			],
+		];
+
+		$actual = $this->builder->block_to_terms( $block );
+		$this->assertEquals( 'Test List Pattern', $actual['terms'][ "pattern-$post_id" ] );
+	}
+
+	function test_it_uses_registered_title_as_term_for_theme_pattern() {
+		register_block_pattern( 'ns/hero', [ 'title' => 'Hero Pattern', 'content' => '<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->' ] );
+
+		$block = [
+			'blockName' => 'core/group',
+			'attrs'     => [
+				'metadata' => [
+					'patternName' => 'ns/hero',
+				],
+			],
+		];
+
+		$actual = $this->builder->block_to_terms( $block );
+		$this->assertEquals( 'Hero Pattern', $actual['terms']['pattern-ns-hero'] );
+	}
+
+	function test_it_ignores_blocks_with_only_metadata_name() {
+		$block = [
+			'blockName' => 'core/group',
+			'attrs'     => [
+				'metadata' => [
+					'name' => 'My Renamed Group',
+				],
+			],
+		];
+
+		$this->assertEmpty( $this->builder->get_pattern_terms( $block ) );
+	}
+
+	function test_it_builds_pattern_post_block_terms() {
+		$content = file_get_contents( FIXTURES_DIR . '/pattern-blocks.html' );
+		$post_id = $this->factory->post->create( [ 'post_content' => $content ] );
+
+		$actual = $this->builder->get_post_block_terms( $post_id );
+
+		$expected = [
+			'core/list'      => 'List',
+			'core/list-item' => 'List Item',
+			'pattern-1412'   => 'Test List Pattern',
+		];
+
+		$this->assertEquals( $expected, $actual['terms'] );
+	}
+
+	function test_it_sets_patterns_parent_term() {
+		$content = file_get_contents( FIXTURES_DIR . '/pattern-blocks.html' );
+		$post_id = $this->factory->post->create( [ 'post_content' => $content ] );
+
+		$terms = $this->builder->get_post_block_terms( $post_id );
+		$this->builder->set_post_block_terms( $post_id, $terms );
+
+		$actual = wp_get_object_terms( $post_id, BLOCK_CATALOG_TAXONOMY, [ 'fields' => 'names' ] );
+
+		$this->assertContains( 'Patterns', $actual );
+		$this->assertContains( 'Test List Pattern', $actual );
+	}
+
+	function test_it_builds_group_pattern_post_block_terms() {
+		$content = file_get_contents( FIXTURES_DIR . '/group-pattern.html' );
+		$post_id = $this->factory->post->create( [ 'post_content' => $content ] );
+
+		$actual = $this->builder->get_post_block_terms( $post_id );
+
+		$expected = [
+			'core/group'     => 'Group',
+			'core/spacer'    => 'Spacer',
+			'core/heading'   => 'Heading',
+			'core/image'     => 'Image',
+			'core/paragraph' => 'Paragraph',
+			'pattern-core-intro-area-with-heading-and-image' => 'Intro',
+		];
+
+		$this->assertEquals( $expected, $actual['terms'] );
+	}
+
+	function test_it_builds_multiple_pattern_post_block_terms() {
+		$content = file_get_contents( FIXTURES_DIR . '/multiple-patterns.html' );
+		$post_id = $this->factory->post->create( [ 'post_content' => $content ] );
+
+		$actual = $this->builder->get_post_block_terms( $post_id );
+
+		$expected = [
+			'core/group'     => 'Group',
+			'core/heading'   => 'Heading',
+			'core/columns'   => 'Columns',
+			'core/column'    => 'Column',
+			'core/paragraph' => 'Paragraph',
+			'pattern-twentytwentyfive-hero'     => 'Hero',
+			'pattern-twentytwentyfive-features' => 'Features',
+		];
+
+		$this->assertEquals( $expected, $actual['terms'] );
+	}
+
 	function test_it_uses_block_label_as_term_for_non_reusable_blocks() {
 		register_block_type( 'ns/foo11', [ 'title' => 'Registered Title' ] );
 

--- a/tests/fixtures/group-pattern.html
+++ b/tests/fixtures/group-pattern.html
@@ -1,0 +1,17 @@
+<!-- wp:group {"metadata":{"name":"Intro","categories":["about"],"patternName":"core/intro-area-with-heading-and-image"},"align":"full","className":"alignfull","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
+<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0"><!-- wp:spacer {"height":"var:preset|spacing|20"} -->
+<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading {"textAlign":"center","level":1} -->
+<h1 class="wp-block-heading has-text-align-center">About Us</h1>
+<!-- /wp:heading -->
+
+<!-- wp:image -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">We make great things.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->

--- a/tests/fixtures/multiple-patterns.html
+++ b/tests/fixtures/multiple-patterns.html
@@ -1,0 +1,13 @@
+<!-- wp:group {"metadata":{"name":"Hero","patternName":"twentytwentyfive/hero"}} -->
+<div class="wp-block-group"><!-- wp:heading -->
+<h2 class="wp-block-heading">Welcome</h2>
+<!-- /wp:heading --></div>
+<!-- /wp:group -->
+
+<!-- wp:columns {"metadata":{"name":"Features","patternName":"twentytwentyfive/features"}} -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:paragraph -->
+<p>feature</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->

--- a/tests/fixtures/pattern-blocks.html
+++ b/tests/fixtures/pattern-blocks.html
@@ -1,0 +1,33 @@
+<!-- wp:list {"ordered":true,"metadata":{"categories":["test1"],"patternName":"core/block/1412","name":"Test List Pattern"}} -->
+<ol class="wp-block-list"><!-- wp:list-item -->
+<li>ordered item</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>ordered item<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li><strong>unordered</strong></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><strong>unordered</strong><!-- wp:list {"ordered":true} -->
+<ol class="wp-block-list"><!-- wp:list-item -->
+<li>ordered item</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>ordered item</li>
+<!-- /wp:list-item --></ol>
+<!-- /wp:list --></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>ordered item</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>ordered item</li>
+<!-- /wp:list-item --></ol>
+<!-- /wp:list -->


### PR DESCRIPTION
### Description of the Change

Adds first-class cataloging of **block patterns**. Until now the catalog indexed block *types* (and synced/reusable blocks) but ignored which **patterns** a post was built from.

Since WP 6.6, inserting a pattern stamps its top-level blocks with a `metadata.patternName` provenance attribute. This PR reads that attribute during indexing and emits an additional `block-catalog` term per pattern, grouped under a new **"Patterns"** parent term, so editors can find/filter posts by pattern just like by block.

- Two `patternName` forms are handled:
  - **User patterns** `core/block/{id}` → slug `pattern-{id}`, label from `get_the_title($id)` (the `wp_block` post title = the name entered when creating the pattern).
  - **Registered/theme patterns** `namespace/slug` → slug `pattern-{sanitized}`, label from `WP_Block_Patterns_Registry`. Fallback chain: source title → `metadata.name` → raw name.

**Note:** Running `wp block-catalog index --reset` (or Delete Index → Index) is required to refresh the catalog.

### How to test the Change

1. On a WP 6.6+ site, create a user pattern, insert it into a post, and publish.
2. Run `wp block-catalog index --reset`.
3. Confirm `Patterns > Your Pattern` appears, and that it shows in the post-list filter dropdown.
4. `wp block-catalog post-blocks <post-id> --type=<any|blocks|patterns>`

### Screenshots

Patterns under block catalog taxonomy:
<img width="1153" height="437" alt="image" src="https://github.com/user-attachments/assets/3da46fe1-3476-4774-877b-a08c7c7d54d1" />

Patterns under block catalog dropdown:
<img width="311" height="972" alt="image" src="https://github.com/user-attachments/assets/988e683d-2b9f-462a-9ba3-5c0d98a59b8f" />


### Changelog Entry

Added - Block pattern support - posts are now cataloged by the block patterns they contain, grouped under a new "Patterns" term.

### Credits

Props @dsawardekar

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
