### PR TITLE
Epic: Adds Support for Block Patterns and Export CLI Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - Use the WP CLI to quickly find blocks from the command line.
 - Use custom WordPress filters to extend the Block Catalog.
 - Find block usage on a Multisite network.
-- Export block catalog data to a CSV file via the WP CLI.
+- Export block catalog data to a CSV file via the WP CLI, optionally scoped to specific blocks.
 
 ## Installation
 
@@ -116,14 +116,20 @@ The following WP CLI commands are supported by the Block Catalog plugin.
   - [--type=\<type\>]
     Filter the output by type — `any` (default), `blocks`, or `patterns`.
 
-- `wp block-catalog export [--output=<output>] [--post_type=<types>] [--posts_per_block=<number>] [--ignore_parent=<ignore_parent>]`
+- `wp block-catalog export [--output=<output>] [--blocks=<blocks>] [--post_type=<types>] [--post_status=<status>] [--posts_per_block=<number>] [--ignore_parent=<ignore_parent>]`
   Exports the posts associated with the 'block_catalog' taxonomy to a CSV file.
 
   - `[--output=<output>]`
     Path to the CSV file. Defaults to `/tmp/block-catalog.csv`.
 
+  - `[--blocks=<blocks>]`
+    Comma-delimited list of blocks to export, by name (eg:- `core/quote`). Use the explicit `namespace/*` form (eg:- `core/*`, quoted so your shell doesn't expand it) to export every block in a namespace. Defaults to all blocks. Optional.
+
   - `[--post_type=<types>]`
     Comma-delimited list of post types. Optional.
+
+  - `[--post_status=<status>]`
+    Comma-delimited list of post statuses to include. Default `publish`. Optional.
 
   - `[--posts_per_block=<number>]`
     Number of posts per block, default to -1 (all). Optional.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - Find which blocks are used across your site.
 - Fully Integrated with the WordPress Admin.
 - Use filters to see Posts that use a specific block.
-- Find Posts that use Reusable Blocks.
+- Find Posts that use Block Patterns.
 - Use the WP CLI to quickly find blocks from the command line.
 - Use custom WordPress filters to extend the Block Catalog.
 - Find block usage on a Multisite network.
@@ -107,11 +107,14 @@ The following WP CLI commands are supported by the Block Catalog plugin.
   - [--network=\<network\>]
     Deletes the indexes across the entire network. Accepts a comma delimited list of child site ids.
 
-- `wp block-catalog post-blocks <post-id> [--index]`
-  Prints the list of blocks in the specified post.
+- `wp block-catalog post-blocks <post-id> [--type=<type>]`
+  Prints the blocks and patterns used in the specified post.
 
   - \<post-id\>
-    The post id to lookup blocks for.
+    The post id to look up.
+
+  - [--type=\<type\>]
+    Filter the output by type — `any` (default), `blocks`, or `patterns`.
 
 - `wp block-catalog export [--output=<output>] [--post_type=<types>] [--posts_per_block=<number>] [--ignore_parent=<ignore_parent>]`
   Exports the posts associated with the 'block_catalog' taxonomy to a CSV file.

--- a/README.md
+++ b/README.md
@@ -116,14 +116,17 @@ The following WP CLI commands are supported by the Block Catalog plugin.
   - [--type=\<type\>]
     Filter the output by type — `any` (default), `blocks`, or `patterns`.
 
-- `wp block-catalog export [--output=<output>] [--blocks=<blocks>] [--post_type=<types>] [--post_status=<status>] [--posts_per_block=<number>] [--ignore_parent=<ignore_parent>]`
+- `wp block-catalog export [--output=<output>] [--blocks=<blocks>] [--patterns=<patterns>] [--post_type=<types>] [--post_status=<status>] [--posts_per_block=<number>] [--ignore_parent=<ignore_parent>]`
   Exports the posts associated with the 'block_catalog' taxonomy to a CSV file.
 
   - `[--output=<output>]`
     Path to the CSV file. Defaults to `/tmp/block-catalog.csv`.
 
   - `[--blocks=<blocks>]`
-    Comma-delimited list of blocks to export, by name (eg:- `core/quote`). Use the explicit `namespace/*` form (eg:- `core/*`, quoted so your shell doesn't expand it) to export every block in a namespace. Defaults to all blocks. Optional.
+    Comma-delimited list of blocks to export, by name (eg:- `core/quote`). Use the `namespace/*` form (eg:- `core/*`, quoted so your shell doesn't expand it) to export a whole namespace, or `*` for all blocks. Defaults to all blocks. Optional.
+
+  - `[--patterns=<patterns>]`
+    Comma-delimited list of block patterns to export, by name (eg:- `foo/something`), a `namespace/*` fan-out (eg:- `foo/*`, quoted), or `*` for all patterns. Cannot be combined with `--blocks`. Optional.
 
   - `[--post_type=<types>]`
     Comma-delimited list of post types. Optional.
@@ -136,6 +139,8 @@ The following WP CLI commands are supported by the Block Catalog plugin.
 
   - `[--ignore_parent=<ignore_parent>]`
     Ignore top level blocks. Optional. Default true.
+
+  The exported CSV columns are `block_name`, `block_slug`, `post_id`, `post_type`, `post_title`, `permalink`, `post_status`, `edit_link`, `post_author`, `post_date`, `post_modified`, and a blank `notes` column for QA sign-off. For `--patterns` exports, the first two columns are `pattern_name` and `pattern_slug` instead.
 
 ## Frequently Asked Questions
 

--- a/includes/classes/CatalogBuilder.php
+++ b/includes/classes/CatalogBuilder.php
@@ -440,13 +440,38 @@ class CatalogBuilder {
 			return [];
 		}
 
-		$slug = $this->get_pattern_slug( $block );
+		$path = $this->get_pattern_path( $block );
 
-		if ( empty( $slug ) ) {
+		if ( empty( $path ) ) {
 			return [];
 		}
 
-		return [ $slug => $this->get_pattern_label( $block ) ];
+		return [ $path => $this->get_pattern_label( $block ) ];
+	}
+
+	/**
+	 * Finds the catalog path for the block's pattern.
+	 *
+	 * Mirrors block paths (eg:- core/heading) so the term hierarchy and slug line up: a
+	 * registered pattern foo/hero becomes patterns/foo/hero (slug patterns-foo-hero), and a
+	 * user/synced pattern becomes patterns/user/<id>.
+	 *
+	 * @param array $block The block data
+	 * @return string
+	 */
+	public function get_pattern_path( $block ) {
+		$name = $block['attrs']['metadata']['patternName'] ?? '';
+
+		if ( empty( $name ) ) {
+			return '';
+		}
+
+		if ( $this->is_user_pattern( $name ) ) {
+			$id = $this->get_user_pattern_id( $name );
+			return ! empty( $id ) ? 'patterns/user/' . $id : '';
+		}
+
+		return 'patterns/' . $name;
 	}
 
 	/**
@@ -456,14 +481,7 @@ class CatalogBuilder {
 	 * @return string
 	 */
 	public function get_pattern_slug( $block ) {
-		$name = $block['attrs']['metadata']['patternName'];
-
-		if ( $this->is_user_pattern( $name ) ) {
-			$id = $this->get_user_pattern_id( $name );
-			return ! empty( $id ) ? 'pattern-' . $id : '';
-		}
-
-		return 'pattern-' . sanitize_title( $name );
+		return sanitize_title( $this->get_pattern_path( $block ) );
 	}
 
 	/**
@@ -496,7 +514,7 @@ class CatalogBuilder {
 	 * @return bool
 	 */
 	public function is_pattern_term( $slug ) {
-		return 0 === stripos( $slug, 'pattern-' ) || 0 === stripos( $slug, 're-' );
+		return 0 === stripos( $slug, 'patterns-' ) || 0 === stripos( $slug, 're-' );
 	}
 
 	/**
@@ -557,10 +575,6 @@ class CatalogBuilder {
 			return __( 'Reusable block', 'block-catalog' );
 		}
 
-		if ( 0 === stripos( $name, 'pattern-' ) ) {
-			return __( 'Patterns', 'block-catalog' );
-		}
-
 		$parts     = explode( '/', $name );
 		$namespace = count( $parts ) > 1 ? $parts[0] : '';
 
@@ -587,6 +601,11 @@ class CatalogBuilder {
 	 * @return int|false
 	 */
 	public function get_block_parent_term( $name ) {
+		// Patterns are hierarchical paths (eg:- patterns/foo/hero); build the chain by slug.
+		if ( $this->is_pattern_path( $name ) ) {
+			return $this->get_pattern_parent_term( $name );
+		}
+
 		$name = $this->get_block_parent_name( $name );
 
 		if ( empty( $name ) ) {
@@ -601,6 +620,57 @@ class CatalogBuilder {
 		}
 
 		$result = wp_insert_term( $name, BLOCK_CATALOG_TAXONOMY, [] );
+
+		if ( ! is_wp_error( $result ) ) {
+			return intval( $result['term_id'] );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if a term key is a hierarchical pattern path, eg:- patterns/foo/hero.
+	 *
+	 * @param string $name The term key (block name or pattern path).
+	 * @return bool
+	 */
+	public function is_pattern_path( $name ) {
+		return 'patterns' === $name || 0 === stripos( $name, 'patterns/' );
+	}
+
+	/**
+	 * Resolves, creating if absent, the parent term for a pattern path — building the
+	 * Patterns > Namespace > Pattern chain by slug. Each level's slug is the sanitized
+	 * path (eg:- patterns, patterns-foo), mirroring how blocks nest under their namespace.
+	 *
+	 * @param string $path The pattern path, eg:- patterns/foo/hero.
+	 * @return int|false The parent term id, or false when the path is top-level.
+	 */
+	public function get_pattern_parent_term( $path ) {
+		$segments = explode( '/', $path );
+		array_pop( $segments );
+
+		if ( empty( $segments ) ) {
+			return false;
+		}
+
+		$parent_path = implode( '/', $segments );
+		$slug        = sanitize_title( $parent_path );
+		$existing    = get_term_by( 'slug', $slug, BLOCK_CATALOG_TAXONOMY );
+
+		if ( ! empty( $existing ) ) {
+			return intval( $existing->term_id );
+		}
+
+		$args        = [ 'slug' => $slug ];
+		$grandparent = $this->get_pattern_parent_term( $parent_path );
+
+		if ( ! empty( $grandparent ) ) {
+			$args['parent'] = $grandparent;
+		}
+
+		$label  = $this->get_display_title( end( $segments ) );
+		$result = wp_insert_term( $label, BLOCK_CATALOG_TAXONOMY, $args );
 
 		if ( ! is_wp_error( $result ) ) {
 			return intval( $result['term_id'] );

--- a/includes/classes/CatalogBuilder.php
+++ b/includes/classes/CatalogBuilder.php
@@ -490,6 +490,16 @@ class CatalogBuilder {
 	}
 
 	/**
+	 * Checks if a catalog term slug belongs to a pattern, including synced/reusable patterns.
+	 *
+	 * @param string $slug The term slug
+	 * @return bool
+	 */
+	public function is_pattern_term( $slug ) {
+		return 0 === stripos( $slug, 'pattern-' ) || 0 === stripos( $slug, 're-' );
+	}
+
+	/**
 	 * Finds the label of the block term from its blockName.
 	 *
 	 * @param string $block The block data

--- a/includes/classes/CatalogBuilder.php
+++ b/includes/classes/CatalogBuilder.php
@@ -372,6 +372,8 @@ class CatalogBuilder {
 			$terms[ $block['blockName'] ] = $label;
 		}
 
+		$terms = array_replace( $terms, $this->get_pattern_terms( $block ) );
+
 		/**
 		 * Filters the term labels corresponding to the block in the catalog. This
 		 * is useful to build multiple terms from a single block.
@@ -395,6 +397,96 @@ class CatalogBuilder {
 			'terms'      => $terms,
 			'variations' => $variations,
 		];
+	}
+
+	/**
+	 * Checks if the block originated from a block pattern.
+	 *
+	 * @param array $block The block data
+	 * @return bool
+	 */
+	public function is_pattern_block( $block ) {
+		return ! empty( $block['attrs']['metadata']['patternName'] );
+	}
+
+	/**
+	 * Checks if the pattern name refers to a user pattern, ie:- a wp_block post.
+	 *
+	 * @param string $name The pattern name
+	 * @return bool
+	 */
+	public function is_user_pattern( $name ) {
+		return 0 === stripos( $name, 'core/block/' );
+	}
+
+	/**
+	 * Returns the wp_block post id from a user pattern name.
+	 *
+	 * @param string $name The pattern name, eg:- core/block/1412
+	 * @return int
+	 */
+	public function get_user_pattern_id( $name ) {
+		return intval( substr( $name, strlen( 'core/block/' ) ) );
+	}
+
+	/**
+	 * Converts a block's pattern to a list of term names.
+	 *
+	 * @param array $block The block data
+	 * @return array
+	 */
+	public function get_pattern_terms( $block ) {
+		if ( ! $this->is_pattern_block( $block ) ) {
+			return [];
+		}
+
+		$slug = $this->get_pattern_slug( $block );
+
+		if ( empty( $slug ) ) {
+			return [];
+		}
+
+		return [ $slug => $this->get_pattern_label( $block ) ];
+	}
+
+	/**
+	 * Finds the catalog slug for the block's pattern.
+	 *
+	 * @param array $block The block data
+	 * @return string
+	 */
+	public function get_pattern_slug( $block ) {
+		$name = $block['attrs']['metadata']['patternName'];
+
+		if ( $this->is_user_pattern( $name ) ) {
+			$id = $this->get_user_pattern_id( $name );
+			return ! empty( $id ) ? 'pattern-' . $id : '';
+		}
+
+		return 'pattern-' . sanitize_title( $name );
+	}
+
+	/**
+	 * Finds the display label for the block's pattern.
+	 *
+	 * @param array $block The block data
+	 * @return string
+	 */
+	public function get_pattern_label( $block ) {
+		$name = $block['attrs']['metadata']['patternName'];
+
+		if ( $this->is_user_pattern( $name ) ) {
+			$label = get_the_title( $this->get_user_pattern_id( $name ) );
+		} else {
+			$registered = \WP_Block_Patterns_Registry::get_instance()->get_registered( $name );
+			$label      = ! empty( $registered['title'] ) ? $registered['title'] : '';
+		}
+
+		if ( empty( $label ) ) {
+			$label = $block['attrs']['metadata']['name'] ?? $name;
+		}
+
+		return $label;
 	}
 
 	/**
@@ -453,6 +545,10 @@ class CatalogBuilder {
 	public function get_block_parent_name( $name ) {
 		if ( 0 === stripos( $name, 're-' ) ) {
 			return __( 'Reusable block', 'block-catalog' );
+		}
+
+		if ( 0 === stripos( $name, 'pattern-' ) ) {
+			return __( 'Patterns', 'block-catalog' );
 		}
 
 		$parts     = explode( '/', $name );

--- a/includes/classes/CatalogCommand.php
+++ b/includes/classes/CatalogCommand.php
@@ -179,6 +179,9 @@ class CatalogCommand extends \WP_CLI_Command {
 	 * <post-id>
 	 * : The post id to lookup blocks for.
 	 *
+	 * [--type=<type>]
+	 * : Filter terms by type. One of 'any', 'blocks', 'patterns'. Default 'any'.
+	 *
 	 * @subcommand post-blocks
 	 * @param array $args Command args
 	 * @param array $opts Command opts
@@ -188,28 +191,42 @@ class CatalogCommand extends \WP_CLI_Command {
 			\WP_CLI::error( __( 'Please enter a valid post_id', 'block-catalog' ) );
 		}
 
+		$type = isset( $opts['type'] ) ? $opts['type'] : 'any';
+
+		if ( ! in_array( $type, [ 'any', 'blocks', 'patterns' ], true ) ) {
+			\WP_CLI::error( __( "Invalid --type, expected one of 'any', 'blocks' or 'patterns'.", 'block-catalog' ) );
+		}
+
 		$post_id = intval( $args[0] );
 
 		$builder = new CatalogBuilder();
 		$builder->catalog( $post_id );
 
 		$blocks = wp_get_object_terms( $post_id, BLOCK_CATALOG_TAXONOMY );
+		$blocks = $this->filter_post_blocks( $blocks, $type );
 
 		if ( empty( $blocks ) ) {
-			\WP_CLI::error( __( 'No blocks found.', 'block-catalog' ) );
+			\WP_CLI::error(
+				'patterns' === $type
+					? __( 'No patterns found.', 'block-catalog' )
+					: __( 'No blocks found.', 'block-catalog' )
+			);
 		}
 
+		$name_label = 'patterns' === $type ? 'Pattern Name' : 'Block Name';
+
 		$block_items = array_map(
-			function ( $term ) {
+			function ( $term ) use ( $name_label ) {
 				return [
-					'Block' => $term->name,
-					'ID'    => $term->term_id,
+					'ID'        => $term->term_id,
+					$name_label => $term->name,
+					'Slug'      => $term->slug,
 				];
 			},
 			$blocks
 		);
 
-		\WP_CLI\Utils\format_items( 'table', $block_items, [ 'ID', 'Block' ] );
+		\WP_CLI\Utils\format_items( 'table', $block_items, [ 'ID', $name_label, 'Slug' ] );
 	}
 
 	/**
@@ -257,6 +274,36 @@ class CatalogCommand extends \WP_CLI_Command {
 		} else {
 			\WP_CLI::success( $result['message'] );
 		}
+	}
+
+	/**
+	 * Filters a post's catalog terms by type, dropping grouping parent terms.
+	 *
+	 * @param array  $terms The post's catalog terms
+	 * @param string $type The type filter, one of 'any', 'blocks' or 'patterns'
+	 * @return array
+	 */
+	private function filter_post_blocks( $terms, $type ) {
+		$builder = new CatalogBuilder();
+
+		return array_filter(
+			$terms,
+			function ( $term ) use ( $type, $builder ) {
+				if ( 0 === $term->parent ) {
+					return false;
+				}
+
+				if ( 'patterns' === $type ) {
+					return $builder->is_pattern_term( $term->slug );
+				}
+
+				if ( 'blocks' === $type ) {
+					return ! $builder->is_pattern_term( $term->slug );
+				}
+
+				return true;
+			}
+		);
 	}
 
 	/**

--- a/includes/classes/CatalogCommand.php
+++ b/includes/classes/CatalogCommand.php
@@ -242,6 +242,11 @@ class CatalogCommand extends \WP_CLI_Command {
 	 * (eg:- core-quote). Use the explicit 'namespace/*' form (eg:- core/*) to export
 	 * every block in a namespace. Defaults to all blocks. Optional.
 	 *
+	 * [--patterns=<patterns>]
+	 * : Comma-delimited list of registered block patterns to export, by name (eg:-
+	 * foo/something). Converted to pattern catalog slugs. Cannot be combined with
+	 * --blocks. Optional.
+	 *
 	 * [--post_type=<types>]
 	 * : Comma-delimited list of post types. Optional.
 	 *
@@ -262,6 +267,8 @@ class CatalogCommand extends \WP_CLI_Command {
 	 *
 	 *     wp block-catalog export --blocks='core/*' --output=path/to/csv
 	 *
+	 *     wp block-catalog export --patterns=foo/something --output=path/to/csv
+	 *
 	 * @when after_wp_load
 	 *
 	 * @param array $args Positional arguments.
@@ -278,12 +285,21 @@ class CatalogCommand extends \WP_CLI_Command {
 		$opts['posts_per_block'] = $posts_per_block;
 		$opts['post_status']     = $post_status;
 
+		$exporter = new \BlockCatalog\CatalogExporter();
+
+		if ( isset( $opts['patterns'] ) && isset( $opts['blocks'] ) ) {
+			\WP_CLI::error( __( 'Please use either --patterns or --blocks, not both.', 'block-catalog' ) );
+		}
+
+		if ( isset( $opts['patterns'] ) ) {
+			$opts['blocks'] = $exporter->patterns_to_block_slugs( $opts['patterns'] );
+		}
+
 		if ( isset( $opts['blocks'] ) ) {
 			$opts['blocks'] = $this->resolve_export_blocks( $opts['blocks'] );
 		}
 
-		$exporter = new \BlockCatalog\CatalogExporter();
-		$result   = $exporter->export( $output, $opts );
+		$result = $exporter->export( $output, $opts );
 
 		if ( is_wp_error( $result ) ) {
 			\WP_CLI::error( $result->get_error_message() );

--- a/includes/classes/CatalogCommand.php
+++ b/includes/classes/CatalogCommand.php
@@ -237,8 +237,16 @@ class CatalogCommand extends \WP_CLI_Command {
 	 * [--output=<output>]
 	 * : Path to the CSV file. Defaults to /tmp/block-catalog.csv
 	 *
+	 * [--blocks=<blocks>]
+	 * : Comma-delimited list of blocks to export, by name (eg:- core/quote) or slug
+	 * (eg:- core-quote). Use the explicit 'namespace/*' form (eg:- core/*) to export
+	 * every block in a namespace. Defaults to all blocks. Optional.
+	 *
 	 * [--post_type=<types>]
 	 * : Comma-delimited list of post types. Optional.
+	 *
+	 * [--post_status=<status>]
+	 * : Comma-delimited list of post statuses to include. Default 'publish'. Optional.
 	 *
 	 * [--posts_per_block=<number>]
 	 * : Number of posts per block, default to -1 (all). Optional.
@@ -250,6 +258,10 @@ class CatalogCommand extends \WP_CLI_Command {
 	 *
 	 *     wp block-catalog export --output=path/to/csv
 	 *
+	 *     wp block-catalog export --blocks=core/quote,core/pullquote --output=path/to/csv
+	 *
+	 *     wp block-catalog export --blocks='core/*' --output=path/to/csv
+	 *
 	 * @when after_wp_load
 	 *
 	 * @param array $args Positional arguments.
@@ -259,10 +271,16 @@ class CatalogCommand extends \WP_CLI_Command {
 		$output          = isset( $opts['output'] ) ? $opts['output'] : '/tmp/block-catalog.csv';
 		$post_types      = isset( $opts['post_type'] ) ? explode( ',', $opts['post_type'] ) : array();
 		$posts_per_block = isset( $opts['posts_per_block'] ) ? intval( $opts['posts_per_block'] ) : -1;
+		$post_status     = isset( $opts['post_status'] ) ? explode( ',', $opts['post_status'] ) : array( 'publish' );
 
 		$opts['output']          = $output;
 		$opts['post_type']       = $post_types;
 		$opts['posts_per_block'] = $posts_per_block;
+		$opts['post_status']     = $post_status;
+
+		if ( isset( $opts['blocks'] ) ) {
+			$opts['blocks'] = $this->resolve_export_blocks( $opts['blocks'] );
+		}
 
 		$exporter = new \BlockCatalog\CatalogExporter();
 		$result   = $exporter->export( $output, $opts );
@@ -274,6 +292,36 @@ class CatalogCommand extends \WP_CLI_Command {
 		} else {
 			\WP_CLI::success( $result['message'] );
 		}
+	}
+
+	/**
+	 * Resolves the --blocks option into a validated list of catalog term slugs.
+	 *
+	 * Warns for any block name that doesn't match an indexed block, and aborts if the
+	 * catalog isn't indexed or none of the requested blocks match.
+	 *
+	 * @param string $blocks The raw --blocks option value.
+	 * @return array List of resolved term slugs.
+	 */
+	public function resolve_export_blocks( $blocks ) {
+		$finder = new PostFinder();
+
+		if ( ! $finder->is_indexed() ) {
+			\WP_CLI::error( __( 'Block Catalog index is empty, please index the site first.', 'block-catalog' ) );
+		}
+
+		$resolved = $finder->resolve_block_filter( $blocks );
+
+		foreach ( $resolved['unmatched'] as $name ) {
+			// translators: %s is the block name that was not found.
+			\WP_CLI::warning( sprintf( __( 'No indexed block found for "%s", skipping.', 'block-catalog' ), $name ) );
+		}
+
+		if ( empty( $resolved['slugs'] ) ) {
+			\WP_CLI::error( __( 'None of the specified blocks matched an indexed block.', 'block-catalog' ) );
+		}
+
+		return $resolved['slugs'];
 	}
 
 	/**

--- a/includes/classes/CatalogCommand.php
+++ b/includes/classes/CatalogCommand.php
@@ -239,13 +239,13 @@ class CatalogCommand extends \WP_CLI_Command {
 	 *
 	 * [--blocks=<blocks>]
 	 * : Comma-delimited list of blocks to export, by name (eg:- core/quote) or slug
-	 * (eg:- core-quote). Use the explicit 'namespace/*' form (eg:- core/*) to export
-	 * every block in a namespace. Defaults to all blocks. Optional.
+	 * (eg:- core-quote). Use the 'namespace/*' form (eg:- core/*) to export a whole
+	 * namespace, or '*' for all blocks. Defaults to all blocks. Optional.
 	 *
 	 * [--patterns=<patterns>]
-	 * : Comma-delimited list of registered block patterns to export, by name (eg:-
-	 * foo/something). Converted to pattern catalog slugs. Cannot be combined with
-	 * --blocks. Optional.
+	 * : Comma-delimited list of block patterns to export, by name (eg:- foo/something),
+	 * a 'namespace/*' fan-out (eg:- foo/*), or '*' for all patterns. Cannot be combined
+	 * with --blocks. Optional.
 	 *
 	 * [--post_type=<types>]
 	 * : Comma-delimited list of post types. Optional.
@@ -313,13 +313,19 @@ class CatalogCommand extends \WP_CLI_Command {
 	/**
 	 * Resolves the --blocks option into a validated list of catalog term slugs.
 	 *
-	 * Warns for any block name that doesn't match an indexed block, and aborts if the
-	 * catalog isn't indexed or none of the requested blocks match.
+	 * A '*' token short-circuits to an empty list, meaning no filtering (export everything).
+	 * Otherwise warns for any block name that doesn't match an indexed block, and aborts if
+	 * the catalog isn't indexed or none of the requested blocks match.
 	 *
 	 * @param string $blocks The raw --blocks option value.
-	 * @return array List of resolved term slugs.
+	 * @return array List of resolved term slugs ([] = no filter / export all).
 	 */
 	private function resolve_export_blocks( $blocks ) {
+		// A '*' means everything, so skip filtering and export all catalog terms.
+		if ( '*' === $blocks ) {
+			return [];
+		}
+
 		$finder = new PostFinder();
 
 		if ( ! $finder->is_indexed() ) {

--- a/includes/classes/CatalogCommand.php
+++ b/includes/classes/CatalogCommand.php
@@ -303,7 +303,7 @@ class CatalogCommand extends \WP_CLI_Command {
 	 * @param string $blocks The raw --blocks option value.
 	 * @return array List of resolved term slugs.
 	 */
-	public function resolve_export_blocks( $blocks ) {
+	private function resolve_export_blocks( $blocks ) {
 		$finder = new PostFinder();
 
 		if ( ! $finder->is_indexed() ) {

--- a/includes/classes/CatalogExporter.php
+++ b/includes/classes/CatalogExporter.php
@@ -81,6 +81,28 @@ class CatalogExporter {
 	}
 
 	/**
+	 * Converts a comma-delimited list of pattern names into the equivalent --blocks value.
+	 *
+	 * Each pattern name (eg:- foo/something) maps to its catalog term slug
+	 * (eg:- pattern-foo-something), matching CatalogBuilder::get_pattern_slug().
+	 *
+	 * @param string $patterns Comma-delimited list of pattern names.
+	 * @return string Comma-delimited list of pattern term slugs.
+	 */
+	public function patterns_to_block_slugs( $patterns ) {
+		$names = array_filter( array_map( 'trim', explode( ',', (string) $patterns ) ) );
+
+		$slugs = array_map(
+			function ( $name ) {
+				return 'pattern-' . sanitize_title( $name );
+			},
+			$names
+		);
+
+		return implode( ',', $slugs );
+	}
+
+	/**
 	 * Retrieves the terms associated with the 'block_catalog' taxonomy.
 	 *
 	 * When the 'blocks' option holds a list of slugs, only those terms are returned;

--- a/includes/classes/CatalogExporter.php
+++ b/includes/classes/CatalogExporter.php
@@ -50,7 +50,11 @@ class CatalogExporter {
 
 		$total_posts = $this->get_total_posts( $terms, $opts );
 
-		$this->put_csv( array( 'block_name', 'block_slug', 'post_id', 'post_type', 'post_title', 'permalink', 'post_status', 'edit_link', 'post_author', 'post_date', 'post_modified', 'notes' ) );
+		$is_patterns = ! empty( $opts['patterns'] );
+		$name_column = $is_patterns ? 'pattern_name' : 'block_name';
+		$slug_column = $is_patterns ? 'pattern_slug' : 'block_slug';
+
+		$this->put_csv( array( $name_column, $slug_column, 'post_id', 'post_type', 'post_title', 'permalink', 'post_status', 'edit_link', 'post_author', 'post_date', 'post_modified', 'notes' ) );
 
 		// when running in WP CLI mode, there is a progress bar
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/includes/classes/CatalogExporter.php
+++ b/includes/classes/CatalogExporter.php
@@ -31,7 +31,7 @@ class CatalogExporter {
 			return new \WP_Error( 'output_not_writable', __( 'The output path is not writable', 'block-catalog' ) );
 		}
 
-		$terms = $this->get_block_catalog_terms();
+		$terms = $this->get_block_catalog_terms( $opts );
 
 		// check for WP_Error
 		if ( is_wp_error( $terms ) ) {
@@ -50,7 +50,7 @@ class CatalogExporter {
 
 		$total_posts = $this->get_total_posts( $terms, $opts );
 
-		$this->put_csv( array( 'block_name', 'block_slug', 'post_id', 'post_type', 'post_title', 'permalink', 'status' ) );
+		$this->put_csv( array( 'block_name', 'block_slug', 'post_id', 'post_type', 'post_title', 'permalink', 'post_status', 'edit_link', 'post_author', 'post_date', 'post_modified', 'notes' ) );
 
 		// when running in WP CLI mode, there is a progress bar
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
@@ -81,17 +81,26 @@ class CatalogExporter {
 	}
 
 	/**
-	 * Retrieves all terms associated with the 'block_catalog' taxonomy.
+	 * Retrieves the terms associated with the 'block_catalog' taxonomy.
 	 *
+	 * When the 'blocks' option holds a list of slugs, only those terms are returned;
+	 * otherwise all catalog terms are returned.
+	 *
+	 * @param array $opts Options for the export. Supports 'blocks' => array of slugs.
 	 * @return array List of WP_Term objects.
 	 */
-	private function get_block_catalog_terms() {
-		return get_terms(
-			array(
-				'taxonomy'   => BLOCK_CATALOG_TAXONOMY,
-				'hide_empty' => false,
-			)
+	public function get_block_catalog_terms( $opts = [] ) {
+		$args = array(
+			'taxonomy'   => BLOCK_CATALOG_TAXONOMY,
+			'hide_empty' => false,
 		);
+
+		// Restrict to the requested blocks when the --blocks filter is used.
+		if ( ! empty( $opts['blocks'] ) ) {
+			$args['slug'] = $opts['blocks'];
+		}
+
+		return get_terms( $args );
 	}
 
 	/**
@@ -119,7 +128,7 @@ class CatalogExporter {
 	 * @param WP_Term $term The term to export.
 	 * @param array   $opts Options for the export.
 	 */
-	private function export_term( $term, $opts ) {
+	public function export_term( $term, $opts ) {
 		$query_args = $this->get_query_args( $term->slug, $opts );
 		$query      = new \WP_Query( $query_args );
 		$posts      = $query->posts;
@@ -137,6 +146,11 @@ class CatalogExporter {
 					$post->post_title,
 					get_permalink( $post ),
 					$post->post_status,
+					admin_url( "post.php?post={$post->ID}&action=edit" ),
+					get_the_author_meta( 'display_name', $post->post_author ),
+					$post->post_date,
+					$post->post_modified,
+					'',
 				]
 			);
 
@@ -158,9 +172,10 @@ class CatalogExporter {
 	 * @param array  $opts Options for the query.
 	 * @return array Query arguments.
 	 */
-	private function get_query_args( $term_slug, $opts ) {
+	public function get_query_args( $term_slug, $opts ) {
 		return array(
 			'post_type'      => isset( $opts['post_type'] ) ? $opts['post_type'] : get_post_types( array( 'public' => true ) ),
+			'post_status'    => ! empty( $opts['post_status'] ) ? $opts['post_status'] : 'publish',
 			'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				array(
 					'taxonomy' => BLOCK_CATALOG_TAXONOMY,
@@ -231,19 +246,29 @@ class CatalogExporter {
 	}
 
 	/**
-	 * Escapes a string for inclusion in a CSV file.
+	 * Escapes a value for inclusion in a CSV file.
 	 *
-	 * This function adds quotes only if necessary (if the string contains commas, quotes, or newlines).
-	 * It escapes double quotes by doubling them.
+	 * Quotes the value when it contains a comma, double quote, or newline (escaping
+	 * embedded double quotes by doubling them), and neutralizes CSV/spreadsheet formula
+	 * injection by prefixing a leading =, +, -, @, tab, or carriage return with a quote.
 	 *
-	 * @param string $data The input string to be escaped.
-	 * @return string The escaped string.
+	 * @param string $data The input value to be escaped.
+	 * @return string The escaped value.
 	 */
-	private function esc_csv( $data ) {
-		$has_quotes = false !== strpos( $data, '"' );
-		$has_commas = false !== strpos( $data, ',' );
+	public function esc_csv( $data ) {
+		$data = (string) $data;
 
-		if ( $has_quotes || $has_commas ) {
+		// Prevent CSV/spreadsheet formula injection by prefixing risky leading characters.
+		if ( '' !== $data && in_array( $data[0], array( '=', '+', '-', '@', "\t", "\r" ), true ) ) {
+			$data = "'" . $data;
+		}
+
+		$needs_quotes = false !== strpos( $data, '"' )
+			|| false !== strpos( $data, ',' )
+			|| false !== strpos( $data, "\n" )
+			|| false !== strpos( $data, "\r" );
+
+		if ( $needs_quotes ) {
 			$data = str_replace( '"', '""', $data );
 			$data = '"' . $data . '"';
 		}
@@ -258,7 +283,12 @@ class CatalogExporter {
 	 * @param array   $opts Options for the export.
 	 * @return bool True if the term can be exported, false otherwise.
 	 */
-	private function can_export_term( $term, $opts ) {
+	public function can_export_term( $term, $opts ) {
+		// When specific blocks are requested, export exactly those terms.
+		if ( ! empty( $opts['blocks'] ) ) {
+			return true;
+		}
+
 		$ignore_parent = isset( $opts['ignore_parent'] ) ? $opts['ignore_parent'] : true;
 		$ignore_parent = filter_var( $ignore_parent, FILTER_VALIDATE_BOOLEAN );
 

--- a/includes/classes/CatalogExporter.php
+++ b/includes/classes/CatalogExporter.php
@@ -83,11 +83,12 @@ class CatalogExporter {
 	/**
 	 * Converts a comma-delimited list of pattern names into the equivalent --blocks value.
 	 *
-	 * Each token maps to its catalog slug: foo/hero -> patterns-foo-hero, and the namespace
-	 * fan-out foo/* -> patterns-foo/* (the patterns-foo parent), matching the pattern paths
-	 * built by CatalogBuilder.
+	 * Each token maps to its catalog slug: foo/hero -> patterns-foo-hero, the namespace
+	 * fan-out foo/* -> patterns-foo/*, and * -> patterns (the top term; the export query's
+	 * include_children then covers every pattern), matching the pattern paths built by
+	 * CatalogBuilder.
 	 *
-	 * @param string $patterns Comma-delimited list of pattern names / namespace fan-outs.
+	 * @param string $patterns Comma-delimited list of pattern names / fan-outs / *.
 	 * @return string Comma-delimited --blocks value.
 	 */
 	public function patterns_to_block_slugs( $patterns ) {
@@ -95,6 +96,10 @@ class CatalogExporter {
 
 		$slugs = array_map(
 			function ( $token ) {
+				if ( '*' === $token ) {
+					return 'patterns';
+				}
+
 				if ( '/*' === substr( $token, -2 ) ) {
 					return 'patterns-' . sanitize_title( substr( $token, 0, -2 ) ) . '/*';
 				}

--- a/includes/classes/CatalogExporter.php
+++ b/includes/classes/CatalogExporter.php
@@ -83,20 +83,25 @@ class CatalogExporter {
 	/**
 	 * Converts a comma-delimited list of pattern names into the equivalent --blocks value.
 	 *
-	 * Each pattern name (eg:- foo/something) maps to its catalog term slug
-	 * (eg:- pattern-foo-something), matching CatalogBuilder::get_pattern_slug().
+	 * Each token maps to its catalog slug: foo/hero -> patterns-foo-hero, and the namespace
+	 * fan-out foo/* -> patterns-foo/* (the patterns-foo parent), matching the pattern paths
+	 * built by CatalogBuilder.
 	 *
-	 * @param string $patterns Comma-delimited list of pattern names.
-	 * @return string Comma-delimited list of pattern term slugs.
+	 * @param string $patterns Comma-delimited list of pattern names / namespace fan-outs.
+	 * @return string Comma-delimited --blocks value.
 	 */
 	public function patterns_to_block_slugs( $patterns ) {
-		$names = array_filter( array_map( 'trim', explode( ',', (string) $patterns ) ) );
+		$tokens = array_filter( array_map( 'trim', explode( ',', (string) $patterns ) ) );
 
 		$slugs = array_map(
-			function ( $name ) {
-				return 'pattern-' . sanitize_title( $name );
+			function ( $token ) {
+				if ( '/*' === substr( $token, -2 ) ) {
+					return 'patterns-' . sanitize_title( substr( $token, 0, -2 ) ) . '/*';
+				}
+
+				return 'patterns-' . sanitize_title( $token );
 			},
-			$names
+			$tokens
 		);
 
 		return implode( ',', $slugs );

--- a/includes/classes/CatalogExporter.php
+++ b/includes/classes/CatalogExporter.php
@@ -89,7 +89,7 @@ class CatalogExporter {
 	 * @param array $opts Options for the export. Supports 'blocks' => array of slugs.
 	 * @return array List of WP_Term objects.
 	 */
-	private function get_block_catalog_terms( $opts = [] ) {
+	public function get_block_catalog_terms( $opts = [] ) {
 		$args = array(
 			'taxonomy'   => BLOCK_CATALOG_TAXONOMY,
 			'hide_empty' => false,
@@ -172,7 +172,7 @@ class CatalogExporter {
 	 * @param array  $opts Options for the query.
 	 * @return array Query arguments.
 	 */
-	private function get_query_args( $term_slug, $opts ) {
+	public function get_query_args( $term_slug, $opts ) {
 		return array(
 			'post_type'      => isset( $opts['post_type'] ) ? $opts['post_type'] : get_post_types( array( 'public' => true ) ),
 			'post_status'    => ! empty( $opts['post_status'] ) ? $opts['post_status'] : 'publish',
@@ -283,7 +283,7 @@ class CatalogExporter {
 	 * @param array   $opts Options for the export.
 	 * @return bool True if the term can be exported, false otherwise.
 	 */
-	private function can_export_term( $term, $opts ) {
+	public function can_export_term( $term, $opts ) {
 		// When specific blocks are requested, export exactly those terms.
 		if ( ! empty( $opts['blocks'] ) ) {
 			return true;

--- a/includes/classes/CatalogExporter.php
+++ b/includes/classes/CatalogExporter.php
@@ -89,7 +89,7 @@ class CatalogExporter {
 	 * @param array $opts Options for the export. Supports 'blocks' => array of slugs.
 	 * @return array List of WP_Term objects.
 	 */
-	public function get_block_catalog_terms( $opts = [] ) {
+	private function get_block_catalog_terms( $opts = [] ) {
 		$args = array(
 			'taxonomy'   => BLOCK_CATALOG_TAXONOMY,
 			'hide_empty' => false,
@@ -128,7 +128,7 @@ class CatalogExporter {
 	 * @param WP_Term $term The term to export.
 	 * @param array   $opts Options for the export.
 	 */
-	public function export_term( $term, $opts ) {
+	private function export_term( $term, $opts ) {
 		$query_args = $this->get_query_args( $term->slug, $opts );
 		$query      = new \WP_Query( $query_args );
 		$posts      = $query->posts;
@@ -172,7 +172,7 @@ class CatalogExporter {
 	 * @param array  $opts Options for the query.
 	 * @return array Query arguments.
 	 */
-	public function get_query_args( $term_slug, $opts ) {
+	private function get_query_args( $term_slug, $opts ) {
 		return array(
 			'post_type'      => isset( $opts['post_type'] ) ? $opts['post_type'] : get_post_types( array( 'public' => true ) ),
 			'post_status'    => ! empty( $opts['post_status'] ) ? $opts['post_status'] : 'publish',
@@ -283,7 +283,7 @@ class CatalogExporter {
 	 * @param array   $opts Options for the export.
 	 * @return bool True if the term can be exported, false otherwise.
 	 */
-	public function can_export_term( $term, $opts ) {
+	private function can_export_term( $term, $opts ) {
 		// When specific blocks are requested, export exactly those terms.
 		if ( ! empty( $opts['blocks'] ) ) {
 			return true;

--- a/includes/classes/PostFinder.php
+++ b/includes/classes/PostFinder.php
@@ -187,6 +187,111 @@ class PostFinder {
 	}
 
 	/**
+	 * Splits a raw --blocks filter value into a list of trimmed, non-empty tokens.
+	 *
+	 * @param string $value The raw --blocks option value, eg:- 'core/quote, core/*'
+	 * @return array List of block tokens.
+	 */
+	public function parse_block_filter( $value ) {
+		$tokens = explode( ',', (string) $value );
+		$tokens = array_map( 'trim', $tokens );
+		$tokens = array_filter( $tokens );
+
+		return array_values( $tokens );
+	}
+
+	/**
+	 * Checks if a --blocks token is an explicit namespace fan-out, eg:- 'core/*'.
+	 *
+	 * Only the exact 'namespace/*' form is supported, so the namespace itself must not
+	 * contain a slash. Partial globs and sub-patterns are not treated as fan-outs.
+	 *
+	 * @param string $token The --blocks token.
+	 * @return bool
+	 */
+	public function is_namespace_pattern( $token ) {
+		if ( '/*' !== substr( $token, -2 ) ) {
+			return false;
+		}
+
+		$namespace = substr( $token, 0, -2 );
+
+		return '' !== $namespace && false === strpos( $namespace, '/' );
+	}
+
+	/**
+	 * Returns the catalog slugs of all blocks within a namespace.
+	 *
+	 * Block terms are stored as children of their namespace's parent term (see
+	 * CatalogBuilder::get_block_parent_term), so a namespace's blocks are the direct
+	 * children of that parent term.
+	 *
+	 * @param string $ns The block namespace, eg:- 'core'.
+	 * @return array List of child term slugs.
+	 */
+	public function get_namespace_blocks( $ns ) {
+		$parent = get_term_by( 'slug', sanitize_title( $ns ), BLOCK_CATALOG_TAXONOMY );
+
+		if ( empty( $parent ) ) {
+			return [];
+		}
+
+		$slugs = get_terms(
+			[
+				'taxonomy'   => BLOCK_CATALOG_TAXONOMY,
+				'parent'     => $parent->term_id,
+				'hide_empty' => false,
+				'fields'     => 'slugs',
+			]
+		);
+
+		if ( is_wp_error( $slugs ) ) {
+			return [];
+		}
+
+		return $slugs;
+	}
+
+	/**
+	 * Resolves a raw --blocks filter value into catalog term slugs.
+	 *
+	 * Each token is either an explicit namespace fan-out (eg:- 'core/*') or a single
+	 * block by name (eg:- 'core/quote') or slug (eg:- 'core-quote'). Tokens that don't
+	 * match any indexed block are returned in 'unmatched' so the caller can report them.
+	 *
+	 * @param string $value The raw --blocks option value.
+	 * @return array {
+	 *     @type array $slugs     The resolved, unique term slugs.
+	 *     @type array $unmatched The tokens that didn't match any indexed block.
+	 * }
+	 */
+	public function resolve_block_filter( $value ) {
+		$tokens    = $this->parse_block_filter( $value );
+		$slugs     = [];
+		$unmatched = [];
+
+		foreach ( $tokens as $token ) {
+			if ( $this->is_namespace_pattern( $token ) ) {
+				$namespace = substr( $token, 0, -2 );
+				$resolved  = $this->get_namespace_blocks( $namespace );
+			} else {
+				$resolved = $this->get_tax_query_terms( [ $token ] );
+			}
+
+			if ( empty( $resolved ) ) {
+				$unmatched[] = $token;
+			} else {
+				$slugs = array_merge( $slugs, $resolved );
+			}
+		}
+
+		return [
+			'slugs'     => array_values( array_unique( $slugs ) ),
+			'unmatched' => $unmatched,
+		];
+	}
+
+	/**
 	 * Checks if the Block Catalog taxonomy is indexed.
 	 *
 	 * @return bool

--- a/readme.txt
+++ b/readme.txt
@@ -14,6 +14,7 @@ Keep track of which Gutenberg Blocks are used across your site.
 * Fully Integrated with the WordPress Admin.
 * Use filters to see Posts that use a specific block.
 * Find Posts that use Reusable Blocks.
+* Find Posts that use Block Patterns.
 * Use the WP CLI to quickly find blocks from the command line.
 * Use custom WordPress filters to extend the Block Catalog.
 

--- a/readme.txt
+++ b/readme.txt
@@ -17,6 +17,7 @@ Keep track of which Gutenberg Blocks are used across your site.
 * Find Posts that use Block Patterns.
 * Use the WP CLI to quickly find blocks from the command line.
 * Use custom WordPress filters to extend the Block Catalog.
+* Export block catalog data to a CSV file via the WP CLI, optionally scoped to specific blocks.
 
 [Fork on GitHub](https://github.com/10up/block-catalog)
 

--- a/tests/classes/CatalogBuilderTest.php
+++ b/tests/classes/CatalogBuilderTest.php
@@ -133,9 +133,21 @@ class CatalogBuilderTest extends \WP_UnitTestCase {
 		$this->assertEquals( [ "re-$post_id" => 'My Reusable1' ], $actual['terms'] );
 	}
 
-	function test_it_will_use_patterns_as_parent_for_pattern_terms() {
-		$actual = $this->builder->get_block_parent_name( 'pattern-1412' );
-		$this->assertEquals( 'Patterns', $actual );
+	function test_it_detects_pattern_paths() {
+		$this->assertTrue( $this->builder->is_pattern_path( 'patterns' ) );
+		$this->assertTrue( $this->builder->is_pattern_path( 'patterns/ns/hero' ) );
+		$this->assertFalse( $this->builder->is_pattern_path( 'core/heading' ) );
+		$this->assertFalse( $this->builder->is_pattern_path( 're-555' ) );
+	}
+
+	function test_it_nests_patterns_under_namespace_and_top() {
+		$ns_id = $this->builder->get_block_parent_term( 'patterns/ns/hero' );
+		$ns    = get_term( $ns_id );
+		$this->assertEquals( 'patterns-ns', $ns->slug );
+
+		$top = get_term( $ns->parent );
+		$this->assertEquals( 'patterns', $top->slug );
+		$this->assertEquals( 0, (int) $top->parent );
 	}
 
 	function test_it_uses_pattern_name_as_term_for_user_pattern() {
@@ -152,7 +164,7 @@ class CatalogBuilderTest extends \WP_UnitTestCase {
 		];
 
 		$actual = $this->builder->block_to_terms( $block );
-		$this->assertEquals( 'Test List Pattern', $actual['terms'][ "pattern-$post_id" ] );
+		$this->assertEquals( 'Test List Pattern', $actual['terms'][ "patterns/user/$post_id" ] );
 	}
 
 	function test_it_uses_registered_title_as_term_for_theme_pattern() {
@@ -168,7 +180,7 @@ class CatalogBuilderTest extends \WP_UnitTestCase {
 		];
 
 		$actual = $this->builder->block_to_terms( $block );
-		$this->assertEquals( 'Hero Pattern', $actual['terms']['pattern-ns-hero'] );
+		$this->assertEquals( 'Hero Pattern', $actual['terms']['patterns/ns/hero'] );
 	}
 
 	function test_it_ignores_blocks_with_only_metadata_name() {
@@ -191,9 +203,9 @@ class CatalogBuilderTest extends \WP_UnitTestCase {
 		$actual = $this->builder->get_post_block_terms( $post_id );
 
 		$expected = [
-			'core/list'      => 'List',
-			'core/list-item' => 'List Item',
-			'pattern-1412'   => 'Test List Pattern',
+			'core/list'          => 'List',
+			'core/list-item'     => 'List Item',
+			'patterns/user/1412' => 'Test List Pattern',
 		];
 
 		$this->assertEquals( $expected, $actual['terms'] );
@@ -208,8 +220,12 @@ class CatalogBuilderTest extends \WP_UnitTestCase {
 
 		$actual = wp_get_object_terms( $post_id, BLOCK_CATALOG_TAXONOMY, [ 'fields' => 'names' ] );
 
-		$this->assertContains( 'Patterns', $actual );
+		$this->assertContains( 'User', $actual );
 		$this->assertContains( 'Test List Pattern', $actual );
+
+		$user = get_term_by( 'slug', 'patterns-user', BLOCK_CATALOG_TAXONOMY );
+		$top  = get_term_by( 'slug', 'patterns', BLOCK_CATALOG_TAXONOMY );
+		$this->assertEquals( $top->term_id, $user->parent );
 	}
 
 	function test_it_builds_group_pattern_post_block_terms() {
@@ -224,7 +240,7 @@ class CatalogBuilderTest extends \WP_UnitTestCase {
 			'core/heading'   => 'Heading',
 			'core/image'     => 'Image',
 			'core/paragraph' => 'Paragraph',
-			'pattern-core-intro-area-with-heading-and-image' => 'Intro',
+			'patterns/core/intro-area-with-heading-and-image' => 'Intro',
 		];
 
 		$this->assertEquals( $expected, $actual['terms'] );
@@ -242,16 +258,16 @@ class CatalogBuilderTest extends \WP_UnitTestCase {
 			'core/columns'   => 'Columns',
 			'core/column'    => 'Column',
 			'core/paragraph' => 'Paragraph',
-			'pattern-twentytwentyfive-hero'     => 'Hero',
-			'pattern-twentytwentyfive-features' => 'Features',
+			'patterns/twentytwentyfive/hero'     => 'Hero',
+			'patterns/twentytwentyfive/features' => 'Features',
 		];
 
 		$this->assertEquals( $expected, $actual['terms'] );
 	}
 
 	function test_it_knows_pattern_slug_is_a_pattern_term() {
-		$this->assertTrue( $this->builder->is_pattern_term( 'pattern-1412' ) );
-		$this->assertTrue( $this->builder->is_pattern_term( 'pattern-twentytwentyfive-hero' ) );
+		$this->assertTrue( $this->builder->is_pattern_term( 'patterns-user-1412' ) );
+		$this->assertTrue( $this->builder->is_pattern_term( 'patterns-twentytwentyfive-hero' ) );
 	}
 
 	function test_it_treats_reusable_slug_as_a_pattern_term() {

--- a/tests/classes/CatalogBuilderTest.php
+++ b/tests/classes/CatalogBuilderTest.php
@@ -249,6 +249,19 @@ class CatalogBuilderTest extends \WP_UnitTestCase {
 		$this->assertEquals( $expected, $actual['terms'] );
 	}
 
+	function test_it_knows_pattern_slug_is_a_pattern_term() {
+		$this->assertTrue( $this->builder->is_pattern_term( 'pattern-1412' ) );
+		$this->assertTrue( $this->builder->is_pattern_term( 'pattern-twentytwentyfive-hero' ) );
+	}
+
+	function test_it_treats_reusable_slug_as_a_pattern_term() {
+		$this->assertTrue( $this->builder->is_pattern_term( 're-555' ) );
+	}
+
+	function test_it_knows_block_slug_is_not_a_pattern_term() {
+		$this->assertFalse( $this->builder->is_pattern_term( 'core-paragraph' ) );
+	}
+
 	function test_it_uses_block_label_as_term_for_non_reusable_blocks() {
 		register_block_type( 'ns/foo11', [ 'title' => 'Registered Title' ] );
 

--- a/tests/classes/CatalogBuilderTest.php
+++ b/tests/classes/CatalogBuilderTest.php
@@ -133,6 +133,122 @@ class CatalogBuilderTest extends \WP_UnitTestCase {
 		$this->assertEquals( [ "re-$post_id" => 'My Reusable1' ], $actual['terms'] );
 	}
 
+	function test_it_will_use_patterns_as_parent_for_pattern_terms() {
+		$actual = $this->builder->get_block_parent_name( 'pattern-1412' );
+		$this->assertEquals( 'Patterns', $actual );
+	}
+
+	function test_it_uses_pattern_name_as_term_for_user_pattern() {
+		$post_id = $this->factory->post->create( [ 'post_type' => 'wp_block', 'post_title' => 'Test List Pattern' ] );
+
+		$block = [
+			'blockName' => 'core/list',
+			'attrs'     => [
+				'metadata' => [
+					'patternName' => "core/block/$post_id",
+					'name'        => 'Test List Pattern',
+				],
+			],
+		];
+
+		$actual = $this->builder->block_to_terms( $block );
+		$this->assertEquals( 'Test List Pattern', $actual['terms'][ "pattern-$post_id" ] );
+	}
+
+	function test_it_uses_registered_title_as_term_for_theme_pattern() {
+		register_block_pattern( 'ns/hero', [ 'title' => 'Hero Pattern', 'content' => '<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->' ] );
+
+		$block = [
+			'blockName' => 'core/group',
+			'attrs'     => [
+				'metadata' => [
+					'patternName' => 'ns/hero',
+				],
+			],
+		];
+
+		$actual = $this->builder->block_to_terms( $block );
+		$this->assertEquals( 'Hero Pattern', $actual['terms']['pattern-ns-hero'] );
+	}
+
+	function test_it_ignores_blocks_with_only_metadata_name() {
+		$block = [
+			'blockName' => 'core/group',
+			'attrs'     => [
+				'metadata' => [
+					'name' => 'My Renamed Group',
+				],
+			],
+		];
+
+		$this->assertEmpty( $this->builder->get_pattern_terms( $block ) );
+	}
+
+	function test_it_builds_pattern_post_block_terms() {
+		$content = file_get_contents( FIXTURES_DIR . '/pattern-blocks.html' );
+		$post_id = $this->factory->post->create( [ 'post_content' => $content ] );
+
+		$actual = $this->builder->get_post_block_terms( $post_id );
+
+		$expected = [
+			'core/list'      => 'List',
+			'core/list-item' => 'List Item',
+			'pattern-1412'   => 'Test List Pattern',
+		];
+
+		$this->assertEquals( $expected, $actual['terms'] );
+	}
+
+	function test_it_sets_patterns_parent_term() {
+		$content = file_get_contents( FIXTURES_DIR . '/pattern-blocks.html' );
+		$post_id = $this->factory->post->create( [ 'post_content' => $content ] );
+
+		$terms = $this->builder->get_post_block_terms( $post_id );
+		$this->builder->set_post_block_terms( $post_id, $terms );
+
+		$actual = wp_get_object_terms( $post_id, BLOCK_CATALOG_TAXONOMY, [ 'fields' => 'names' ] );
+
+		$this->assertContains( 'Patterns', $actual );
+		$this->assertContains( 'Test List Pattern', $actual );
+	}
+
+	function test_it_builds_group_pattern_post_block_terms() {
+		$content = file_get_contents( FIXTURES_DIR . '/group-pattern.html' );
+		$post_id = $this->factory->post->create( [ 'post_content' => $content ] );
+
+		$actual = $this->builder->get_post_block_terms( $post_id );
+
+		$expected = [
+			'core/group'     => 'Group',
+			'core/spacer'    => 'Spacer',
+			'core/heading'   => 'Heading',
+			'core/image'     => 'Image',
+			'core/paragraph' => 'Paragraph',
+			'pattern-core-intro-area-with-heading-and-image' => 'Intro',
+		];
+
+		$this->assertEquals( $expected, $actual['terms'] );
+	}
+
+	function test_it_builds_multiple_pattern_post_block_terms() {
+		$content = file_get_contents( FIXTURES_DIR . '/multiple-patterns.html' );
+		$post_id = $this->factory->post->create( [ 'post_content' => $content ] );
+
+		$actual = $this->builder->get_post_block_terms( $post_id );
+
+		$expected = [
+			'core/group'     => 'Group',
+			'core/heading'   => 'Heading',
+			'core/columns'   => 'Columns',
+			'core/column'    => 'Column',
+			'core/paragraph' => 'Paragraph',
+			'pattern-twentytwentyfive-hero'     => 'Hero',
+			'pattern-twentytwentyfive-features' => 'Features',
+		];
+
+		$this->assertEquals( $expected, $actual['terms'] );
+	}
+
 	function test_it_uses_block_label_as_term_for_non_reusable_blocks() {
 		register_block_type( 'ns/foo11', [ 'title' => 'Registered Title' ] );
 

--- a/tests/classes/CatalogExporterTest.php
+++ b/tests/classes/CatalogExporterTest.php
@@ -211,4 +211,80 @@ class CatalogExporterTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'plain', $this->exporter->esc_csv( 'plain' ) );
 	}
 
+	function test_it_returns_all_catalog_terms_by_default() {
+		$taxonomy = new BlockCatalogTaxonomy();
+		$taxonomy->register();
+
+		$post_id = $this->factory->post->create( array(
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_content' => '<!-- wp:core/quote --><!-- /wp:core/quote --><!-- wp:core/heading --><!-- /wp:core/heading -->',
+		) );
+		( new CatalogBuilder() )->catalog( $post_id );
+
+		$slugs = wp_list_pluck( $this->exporter->get_block_catalog_terms(), 'slug' );
+
+		$this->assertContains( 'core-quote', $slugs );
+		$this->assertContains( 'core-heading', $slugs );
+	}
+
+	function test_it_restricts_catalog_terms_to_requested_blocks() {
+		$taxonomy = new BlockCatalogTaxonomy();
+		$taxonomy->register();
+
+		$post_id = $this->factory->post->create( array(
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_content' => '<!-- wp:core/quote --><!-- /wp:core/quote --><!-- wp:core/heading --><!-- /wp:core/heading -->',
+		) );
+		( new CatalogBuilder() )->catalog( $post_id );
+
+		$slugs = wp_list_pluck( $this->exporter->get_block_catalog_terms( array( 'blocks' => array( 'core-quote' ) ) ), 'slug' );
+
+		$this->assertEquals( array( 'core-quote' ), $slugs );
+	}
+
+	function test_it_defaults_query_post_status_to_publish() {
+		$args = $this->exporter->get_query_args( 'core-quote', array() );
+
+		$this->assertEquals( 'publish', $args['post_status'] );
+		$this->assertEquals( 'core-quote', $args['tax_query'][0]['terms'] );
+		$this->assertEquals( BLOCK_CATALOG_TAXONOMY, $args['tax_query'][0]['taxonomy'] );
+	}
+
+	function test_it_honors_query_args_options() {
+		$args = $this->exporter->get_query_args(
+			'core-quote',
+			array(
+				'post_status'     => array( 'draft', 'publish' ),
+				'posts_per_block' => 5,
+				'post_type'       => array( 'post' ),
+			)
+		);
+
+		$this->assertEquals( array( 'draft', 'publish' ), $args['post_status'] );
+		$this->assertEquals( 5, $args['posts_per_page'] );
+		$this->assertEquals( array( 'post' ), $args['post_type'] );
+	}
+
+	function test_it_skips_parent_terms_by_default() {
+		$parent = (object) array( 'parent' => 0 );
+		$child  = (object) array( 'parent' => 7 );
+
+		$this->assertFalse( $this->exporter->can_export_term( $parent, array() ) );
+		$this->assertTrue( $this->exporter->can_export_term( $child, array() ) );
+	}
+
+	function test_it_exports_parent_terms_when_ignore_parent_is_false() {
+		$parent = (object) array( 'parent' => 0 );
+
+		$this->assertTrue( $this->exporter->can_export_term( $parent, array( 'ignore_parent' => false ) ) );
+	}
+
+	function test_it_always_exports_explicitly_requested_blocks() {
+		$parent = (object) array( 'parent' => 0 );
+
+		$this->assertTrue( $this->exporter->can_export_term( $parent, array( 'blocks' => array( 'core-quote' ) ) ) );
+	}
+
 }

--- a/tests/classes/CatalogExporterTest.php
+++ b/tests/classes/CatalogExporterTest.php
@@ -287,4 +287,10 @@ class CatalogExporterTest extends \WP_UnitTestCase {
 		$this->assertTrue( $this->exporter->can_export_term( $parent, array( 'blocks' => array( 'core-quote' ) ) ) );
 	}
 
+	function test_it_converts_pattern_names_to_block_slugs() {
+		$this->assertEquals( 'pattern-foo-something', $this->exporter->patterns_to_block_slugs( 'foo/something' ) );
+		$this->assertEquals( 'pattern-foo-a,pattern-bar-b', $this->exporter->patterns_to_block_slugs( 'foo/a, bar/b' ) );
+		$this->assertEquals( '', $this->exporter->patterns_to_block_slugs( '' ) );
+	}
+
 }

--- a/tests/classes/CatalogExporterTest.php
+++ b/tests/classes/CatalogExporterTest.php
@@ -290,8 +290,36 @@ class CatalogExporterTest extends \WP_UnitTestCase {
 	function test_it_converts_pattern_names_to_block_slugs() {
 		$this->assertEquals( 'patterns-foo-something', $this->exporter->patterns_to_block_slugs( 'foo/something' ) );
 		$this->assertEquals( 'patterns-foo/*', $this->exporter->patterns_to_block_slugs( 'foo/*' ) );
+		$this->assertEquals( 'patterns', $this->exporter->patterns_to_block_slugs( '*' ) );
 		$this->assertEquals( 'patterns-foo-a,patterns-bar-b', $this->exporter->patterns_to_block_slugs( 'foo/a, bar/b' ) );
 		$this->assertEquals( '', $this->exporter->patterns_to_block_slugs( '' ) );
+	}
+
+	function test_it_exports_all_patterns_via_the_patterns_term() {
+		$taxonomy = new BlockCatalogTaxonomy();
+		$taxonomy->register();
+
+		$post_id = $this->factory->post->create( array(
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_title'   => 'Pattern Post',
+			'post_content' => '<!-- wp:core/group {"metadata":{"patternName":"foo/hero"}} --><!-- /wp:core/group -->',
+		) );
+
+		( new CatalogBuilder() )->catalog( $post_id );
+
+		// '*' converts to the top 'patterns' term; include_children fans out to every pattern.
+		$result = $this->exporter->export(
+			$this->tmp_file,
+			array(
+				'post_type' => 'post',
+				'blocks'    => array( 'patterns' ),
+			)
+		);
+		$this->assertTrue( $result['success'] );
+
+		$csv = file_get_contents( $this->tmp_file );
+		$this->assertStringContainsString( 'Pattern Post', $csv );
 	}
 
 }

--- a/tests/classes/CatalogExporterTest.php
+++ b/tests/classes/CatalogExporterTest.php
@@ -313,12 +313,15 @@ class CatalogExporterTest extends \WP_UnitTestCase {
 			$this->tmp_file,
 			array(
 				'post_type' => 'post',
+				'patterns'  => '*',
 				'blocks'    => array( 'patterns' ),
 			)
 		);
 		$this->assertTrue( $result['success'] );
 
 		$csv = file_get_contents( $this->tmp_file );
+		$this->assertStringContainsString( 'pattern_name,pattern_slug,post_id', $csv );
+		$this->assertStringNotContainsString( 'block_name,block_slug', $csv );
 		$this->assertStringContainsString( 'Pattern Post', $csv );
 	}
 

--- a/tests/classes/CatalogExporterTest.php
+++ b/tests/classes/CatalogExporterTest.php
@@ -288,8 +288,9 @@ class CatalogExporterTest extends \WP_UnitTestCase {
 	}
 
 	function test_it_converts_pattern_names_to_block_slugs() {
-		$this->assertEquals( 'pattern-foo-something', $this->exporter->patterns_to_block_slugs( 'foo/something' ) );
-		$this->assertEquals( 'pattern-foo-a,pattern-bar-b', $this->exporter->patterns_to_block_slugs( 'foo/a, bar/b' ) );
+		$this->assertEquals( 'patterns-foo-something', $this->exporter->patterns_to_block_slugs( 'foo/something' ) );
+		$this->assertEquals( 'patterns-foo/*', $this->exporter->patterns_to_block_slugs( 'foo/*' ) );
+		$this->assertEquals( 'patterns-foo-a,patterns-bar-b', $this->exporter->patterns_to_block_slugs( 'foo/a, bar/b' ) );
 		$this->assertEquals( '', $this->exporter->patterns_to_block_slugs( '' ) );
 	}
 

--- a/tests/classes/CatalogExporterTest.php
+++ b/tests/classes/CatalogExporterTest.php
@@ -83,10 +83,132 @@ class CatalogExporterTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'Exported successfully', $result['message'] );
 
 		$csv = file_get_contents( $this->tmp_file );
-		$this->assertStringContainsString( 'block_name,block_slug,post_id,post_type,post_title,permalink,status', $csv );
+		$this->assertStringContainsString( 'block_name,block_slug,post_id,post_type,post_title,permalink,post_status,edit_link,post_author,post_date,post_modified,notes', $csv );
 
 		$this->assertStringContainsString( 'Paragraph', $csv );
 		$this->assertStringContainsString( 'core-paragraph', $csv );
+	}
+
+	function test_it_can_export_only_the_requested_blocks() {
+		$taxonomy = new BlockCatalogTaxonomy();
+		$taxonomy->register();
+
+		$quote_post = $this->factory->post->create( array(
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_title'   => 'Quote Post',
+			'post_content' => '<!-- wp:core/quote --><!-- /wp:core/quote -->',
+		) );
+
+		$heading_post = $this->factory->post->create( array(
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_title'   => 'Heading Post',
+			'post_content' => '<!-- wp:core/heading --><!-- /wp:core/heading -->',
+		) );
+
+		$builder = new CatalogBuilder();
+		$builder->catalog( $quote_post );
+		$builder->catalog( $heading_post );
+
+		$opts = array(
+			'post_type' => 'post',
+			'blocks'    => array( 'core-quote' ),
+		);
+
+		$result = $this->exporter->export( $this->tmp_file, $opts );
+		$this->assertTrue( $result['success'] );
+
+		$csv = file_get_contents( $this->tmp_file );
+		$this->assertStringContainsString( 'core-quote', $csv );
+		$this->assertStringNotContainsString( 'core-heading', $csv );
+	}
+
+	function test_it_excludes_non_published_posts_by_default() {
+		$taxonomy = new BlockCatalogTaxonomy();
+		$taxonomy->register();
+
+		$published = $this->factory->post->create( array(
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_title'   => 'Published Quote',
+			'post_content' => '<!-- wp:core/quote --><!-- /wp:core/quote -->',
+		) );
+
+		$draft = $this->factory->post->create( array(
+			'post_type'    => 'post',
+			'post_status'  => 'draft',
+			'post_title'   => 'Draft Quote',
+			'post_content' => '<!-- wp:core/quote --><!-- /wp:core/quote -->',
+		) );
+
+		$builder = new CatalogBuilder();
+		$builder->catalog( $published );
+		$builder->catalog( $draft );
+
+		$result = $this->exporter->export( $this->tmp_file, array( 'post_type' => 'post' ) );
+		$this->assertTrue( $result['success'] );
+
+		$csv = file_get_contents( $this->tmp_file );
+		$this->assertStringContainsString( 'Published Quote', $csv );
+		$this->assertStringNotContainsString( 'Draft Quote', $csv );
+	}
+
+	function test_it_includes_non_published_posts_when_requested() {
+		$taxonomy = new BlockCatalogTaxonomy();
+		$taxonomy->register();
+
+		$draft = $this->factory->post->create( array(
+			'post_type'    => 'post',
+			'post_status'  => 'draft',
+			'post_title'   => 'Draft Quote',
+			'post_content' => '<!-- wp:core/quote --><!-- /wp:core/quote -->',
+		) );
+
+		$builder = new CatalogBuilder();
+		$builder->catalog( $draft );
+
+		$result = $this->exporter->export( $this->tmp_file, array(
+			'post_type'   => 'post',
+			'post_status' => array( 'draft' ),
+		) );
+		$this->assertTrue( $result['success'] );
+
+		$csv = file_get_contents( $this->tmp_file );
+		$this->assertStringContainsString( 'Draft Quote', $csv );
+	}
+
+	function test_it_includes_qa_columns_in_the_header() {
+		$taxonomy = new BlockCatalogTaxonomy();
+		$taxonomy->register();
+
+		$post_id = $this->factory->post->create( array(
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_content' => '<!-- wp:core/paragraph -->Hello<!-- /wp:core/paragraph -->',
+		) );
+
+		$builder = new CatalogBuilder();
+		$builder->catalog( $post_id );
+
+		$result = $this->exporter->export( $this->tmp_file, array( 'post_type' => 'post' ) );
+		$this->assertTrue( $result['success'] );
+
+		$csv = file_get_contents( $this->tmp_file );
+		$this->assertStringContainsString( 'post_status,edit_link,post_author,post_date,post_modified,notes', $csv );
+	}
+
+	function test_it_escapes_csv_formula_injection() {
+		$this->assertEquals( "'=1+1", $this->exporter->esc_csv( '=1+1' ) );
+		$this->assertEquals( "'-2+3", $this->exporter->esc_csv( '-2+3' ) );
+		$this->assertEquals( "'@cmd", $this->exporter->esc_csv( '@cmd' ) );
+	}
+
+	function test_it_quotes_csv_values_with_special_chars() {
+		$this->assertEquals( '"a,b"', $this->exporter->esc_csv( 'a,b' ) );
+		$this->assertEquals( "\"a\nb\"", $this->exporter->esc_csv( "a\nb" ) );
+		$this->assertEquals( '"a""b"', $this->exporter->esc_csv( 'a"b' ) );
+		$this->assertEquals( 'plain', $this->exporter->esc_csv( 'plain' ) );
 	}
 
 }

--- a/tests/classes/PostFinderTest.php
+++ b/tests/classes/PostFinderTest.php
@@ -438,4 +438,61 @@ class PostFinderTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'not-indexed', $actual[2]['error']->get_error_code() );
 	}
 
+	function test_it_parses_block_filter_into_tokens() {
+		$actual = $this->finder->parse_block_filter( 'core/quote, core/*  ,, core-heading' );
+
+		$this->assertEquals( [ 'core/quote', 'core/*', 'core-heading' ], $actual );
+	}
+
+	function test_it_detects_namespace_patterns() {
+		$this->assertTrue( $this->finder->is_namespace_pattern( 'core/*' ) );
+		$this->assertTrue( $this->finder->is_namespace_pattern( 'my-plugin/*' ) );
+
+		$this->assertFalse( $this->finder->is_namespace_pattern( 'core/quote' ) );
+		$this->assertFalse( $this->finder->is_namespace_pattern( 'core/embed*' ) );
+		$this->assertFalse( $this->finder->is_namespace_pattern( '*/quote' ) );
+		$this->assertFalse( $this->finder->is_namespace_pattern( 'core/*/x' ) );
+		$this->assertFalse( $this->finder->is_namespace_pattern( '/*' ) );
+	}
+
+	function test_it_returns_namespace_blocks() {
+		$post_ids = $this->factory->post->create_many( 1, [
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_content' => '<!-- wp:core/paragraph --><!-- /wp:core/paragraph --><!-- wp:core/heading --><!-- /wp:core/heading -->',
+		] );
+
+		foreach ( $post_ids as $post_id ) {
+			$this->builder->catalog( $post_id );
+		}
+
+		$actual = $this->finder->get_namespace_blocks( 'core' );
+		sort( $actual );
+
+		$this->assertEquals( [ 'core-heading', 'core-paragraph' ], $actual );
+		$this->assertNotContains( 'core', $actual );
+	}
+
+	function test_it_returns_empty_for_unknown_namespace() {
+		$this->assertEquals( [], $this->finder->get_namespace_blocks( 'xyz' ) );
+	}
+
+	function test_it_resolves_block_filter_with_names_and_patterns() {
+		$post_ids = $this->factory->post->create_many( 1, [
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_content' => '<!-- wp:core/paragraph --><!-- /wp:core/paragraph --><!-- wp:core/heading --><!-- /wp:core/heading -->',
+		] );
+
+		foreach ( $post_ids as $post_id ) {
+			$this->builder->catalog( $post_id );
+		}
+
+		$actual = $this->finder->resolve_block_filter( 'core/paragraph, core/*, xyz/missing' );
+		sort( $actual['slugs'] );
+
+		$this->assertEquals( [ 'core-heading', 'core-paragraph' ], $actual['slugs'] );
+		$this->assertEquals( [ 'xyz/missing' ], $actual['unmatched'] );
+	}
+
 }

--- a/tests/fixtures/group-pattern.html
+++ b/tests/fixtures/group-pattern.html
@@ -1,0 +1,17 @@
+<!-- wp:group {"metadata":{"name":"Intro","categories":["about"],"patternName":"core/intro-area-with-heading-and-image"},"align":"full","className":"alignfull","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
+<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0"><!-- wp:spacer {"height":"var:preset|spacing|20"} -->
+<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading {"textAlign":"center","level":1} -->
+<h1 class="wp-block-heading has-text-align-center">About Us</h1>
+<!-- /wp:heading -->
+
+<!-- wp:image -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">We make great things.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->

--- a/tests/fixtures/multiple-patterns.html
+++ b/tests/fixtures/multiple-patterns.html
@@ -1,0 +1,13 @@
+<!-- wp:group {"metadata":{"name":"Hero","patternName":"twentytwentyfive/hero"}} -->
+<div class="wp-block-group"><!-- wp:heading -->
+<h2 class="wp-block-heading">Welcome</h2>
+<!-- /wp:heading --></div>
+<!-- /wp:group -->
+
+<!-- wp:columns {"metadata":{"name":"Features","patternName":"twentytwentyfive/features"}} -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:paragraph -->
+<p>feature</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->

--- a/tests/fixtures/pattern-blocks.html
+++ b/tests/fixtures/pattern-blocks.html
@@ -1,0 +1,33 @@
+<!-- wp:list {"ordered":true,"metadata":{"categories":["test1"],"patternName":"core/block/1412","name":"Test List Pattern"}} -->
+<ol class="wp-block-list"><!-- wp:list-item -->
+<li>ordered item</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>ordered item<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li><strong>unordered</strong></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><strong>unordered</strong><!-- wp:list {"ordered":true} -->
+<ol class="wp-block-list"><!-- wp:list-item -->
+<li>ordered item</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>ordered item</li>
+<!-- /wp:list-item --></ol>
+<!-- /wp:list --></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>ordered item</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>ordered item</li>
+<!-- /wp:list-item --></ol>
+<!-- /wp:list -->


### PR DESCRIPTION
### Description of the Change

This epic brings two related capabilities to Block Catalog: it now catalogs the block patterns a post is built from, and it reworks the `export` WP-CLI command into a focused, QA-ready CSV exporter that can target specific blocks or patterns.

#### Block pattern cataloging

Until now the catalog indexed block *types* (and synced/reusable blocks) but ignored which **patterns** a post was built from. Since WP 6.6, inserting a pattern stamps its top-level blocks with a `metadata.patternName` provenance attribute; indexing now reads that and emits a `block-catalog` term per pattern.

Patterns are stored as a **path**, mirroring how blocks nest under their namespace, beneath a new top-level **"Patterns"** term:

This lets editors find/filter posts by pattern in the admin (taxonomy + post-list dropdown) just like by block, and `post-blocks` gains a `--type=any|blocks|patterns` filter.

> **Note:** Run `wp block-catalog index --reset` (or Delete Index → Index) after upgrading to refresh the catalog with patterns.

#### Export CLI updates

`wp block-catalog export` previously only produced a full site-wide dump. It can now produce a focused CSV for the specific block(s) or pattern(s) a developer is working on:

- **`--blocks=<blocks>`**, eg:- core/heading, or core/* for all core blocks
- **`--patterns=<patterns>`**, eg:- my-pattern-ns/my-pattern
- **`--post_status=<status>`**, defaults to `publish` so unpublished content isn't exported unless explicitly requested.

### How to test the Change

**Patterns**
* On a WP 6.6+ site, create a user pattern, insert it into a post, and publish; also insert a registered/theme pattern.
* Run `wp block-catalog index --reset`.
* Confirm `Patterns → User → Your Pattern` (and `Patterns → {Namespace} → {Pattern}` for theme patterns) appear in the Block Catalog taxonomy and the post-list filter dropdown.

**Export**
* `wp block-catalog export --blocks=core/quote --output=/tmp/quote-qa.csv` → Should only export `core/quote` rows.
* `wp block-catalog export --blocks='core/*' --output=/tmp/core.csv` → Should only export `core` rows.
* `wp block-catalog export --patterns='foo/*' --output=/tmp/foo.csv` → Should only export posts associated with the foo pattern

### Screenshots


https://github.com/user-attachments/assets/527de5bc-2486-4df2-8fcc-dacb2734fa8e



### Changelog Entry

> Added - Block pattern support — posts are now cataloged by the block patterns they contain, nested under a new "Patterns" term
> Added - `--blocks`, `--patterns`, and `--post_status` options for `wp block-catalog export` to produce focused, QA-ready CSVs

### Credits

Props @dsawardekar

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
